### PR TITLE
Limit zoom to 11

### DIFF
--- a/components/map/map/component.js
+++ b/components/map/map/component.js
@@ -162,6 +162,7 @@ const Comp = (
         height="100%"
         mapStyle={mapStyle}
         asyncRender
+        maxZoom={11}
         {...internalViewport}
         {...(isStatic
           ? {}


### PR DESCRIPTION
Description of the PR

We have to limit the zoom level to 11 to avoid the processing each time through GEE which is slowing the platform

What to test? How to do it?

Go to the map and zoom. You shouldn't be able to go further than level 11