### PR TITLE
Improved the caching of the API requests

### DIFF
--- a/api/tiles/soc-experimental-change.js
+++ b/api/tiles/soc-experimental-change.js
@@ -74,7 +74,6 @@ module.exports = ({ params: { type, depth, year1, year2, x, y, z } }, res) => {
       });
       await serverPromise.then(serverResponse => {
         res.set('Content-Type', 'image/png');
-        res.set('Cache-Control', 'public,max-age=604800');
         return res.send(Buffer.from(serverResponse.data));
       });
     });

--- a/api/tiles/soc-experimental-timeseries.js
+++ b/api/tiles/soc-experimental-timeseries.js
@@ -65,7 +65,9 @@ module.exports = ({ params: { type, depth, year, x, y, z } }, res) => {
       });
       await serverPromise.then(serverResponse => {
         res.set('Content-Type', 'image/png');
-        res.set('Cache-Control', 'public,max-age=604800');
+        if (z < 5) {
+          res.set('Cache-Control', 'public,max-age=604800');
+        }
         return res.send(Buffer.from(serverResponse.data));
       });
     });

--- a/api/tiles/soc-stock-future-change.js
+++ b/api/tiles/soc-stock-future-change.js
@@ -75,7 +75,6 @@ module.exports = ({ params: { scenario, year, x, y, z } }, res) => {
       });
       await serverPromise.then(serverResponse => {
         res.set('Content-Type', 'image/png');
-        res.set('Cache-Control', 'public,max-age=604800');
         return res.send(Buffer.from(serverResponse.data));
       });
     });

--- a/api/tiles/soc-stock-future-period.js
+++ b/api/tiles/soc-stock-future-period.js
@@ -55,7 +55,9 @@ module.exports = ({ params: { scenario, year, x, y, z } }, res) => {
       });
       await serverPromise.then(serverResponse => {
         res.set('Content-Type', 'image/png');
-        res.set('Cache-Control', 'public,max-age=604800');
+        if (z < 5) {
+          res.set('Cache-Control', 'public,max-age=604800');
+        }
         return res.send(Buffer.from(serverResponse.data));
       });
     });

--- a/api/tiles/soc-stock-historic-change.js
+++ b/api/tiles/soc-stock-historic-change.js
@@ -78,7 +78,6 @@ module.exports = ({ params: { depth, x, y, z } }, res) => {
       });
       await serverPromise.then(serverResponse => {
         res.set('Content-Type', 'image/png');
-        res.set('Cache-Control', 'public,max-age=604800');
         return res.send(Buffer.from(serverResponse.data));
       });
     });

--- a/api/tiles/soc-stock-historic-period.js
+++ b/api/tiles/soc-stock-historic-period.js
@@ -69,7 +69,9 @@ module.exports = ({ params: { depth, period, x, y, z } }, res) => {
       });
       await serverPromise.then(serverResponse => {
         res.set('Content-Type', 'image/png');
-        res.set('Cache-Control', 'public,max-age=604800');
+        if (z < 5) {
+          res.set('Cache-Control', 'public,max-age=604800');
+        }
         return res.send(Buffer.from(serverResponse.data));
       });
     });

--- a/api/tiles/soc-stock-recent-change.js
+++ b/api/tiles/soc-stock-recent-change.js
@@ -35,7 +35,6 @@ module.exports = ({ params: { year1, year2, x, y, z } }, res) => {
       });
       await serverPromise.then(serverResponse => {
         res.set('Content-Type', 'image/png');
-        res.set('Cache-Control', 'public,max-age=604800');
         return res.send(Buffer.from(serverResponse.data));
       });
     });

--- a/api/tiles/soc-stock-recent-timeseries.js
+++ b/api/tiles/soc-stock-recent-timeseries.js
@@ -34,7 +34,9 @@ module.exports = ({ params: { year, x, y, z } }, res) => {
       });
       await serverPromise.then(serverResponse => {
         res.set('Content-Type', 'image/png');
-        res.set('Cache-Control', 'public,max-age=604800');
+        if (z < 5) {
+          res.set('Cache-Control', 'public,max-age=604800');
+        }
         return res.send(Buffer.from(serverResponse.data));
       });
     });

--- a/components/map/map/component.js
+++ b/components/map/map/component.js
@@ -162,6 +162,7 @@ const Comp = (
         height="100%"
         mapStyle={mapStyle}
         asyncRender
+        maxZoom={11}
         {...internalViewport}
         {...(isStatic
           ? {}


### PR DESCRIPTION
Small changes to cache only the requests to the API that have a Z index smaller than 5.
Also removed the caching from the "change" endpoints.

(There were no tests to run nor changelog file)