### PR TITLE
Add new “Change by land cover” widget in the Recent tab

### DIFF
--- a/api/charts/change-by-land-cover.js
+++ b/api/charts/change-by-land-cover.js
@@ -1,0 +1,57 @@
+const axios = require('axios').default;
+
+const { BOUNDARIES } = require('../../components/map/constants');
+const { parseChangeByLandCoverData } = require('./helpers');
+
+const SCENARIOS = {
+  '00': 'crop_MGI',
+  '01': 'crop_I',
+  '02': 'crop_MG',
+  '03': 'grass_full',
+  '04': 'grass_part',
+  '10': 'rewilding',
+  '20': 'degradation_NoDeforestation',
+  '21': 'degradation_ForestToCrop',
+  '22': 'degradation_ForestToGrass',
+};
+
+module.exports = ({ layer, type, boundaries, areaInterest, scenario }) => {
+  // There is no timeseries data for the historic section or the experimental dataset
+  if ((layer === 'soc-stock' && type !== 'recent' && type !== 'future') || layer !== 'soc-stock') {
+    return Promise.resolve([]);
+  }
+
+  const table = `${BOUNDARIES[boundaries].table}_land_cover`;
+
+  let query = `${process.env.API_URL}/sql?q=SELECT * FROM ${table} WHERE group_type = '${
+    type === 'future' ? SCENARIOS[scenario] : type
+  }' AND id = ${areaInterest}`;
+
+  // Carto may incorrectly cache the data (the cache is not cleaned when data changes) so to avoid
+  // that, we send a dummy parameter (here `t`), which contains today's date
+  // In addition, we want to clean the cache each time we deploy, so we use another parameter, `d`,
+  // which contains the deployment key
+  query = `${query}&t=${new Date().toISOString().split('T')[0]}&d=${process.env.DEPLOYMENT_KEY}`;
+
+  return axios
+    .get(query, {
+      headers: { Accept: 'application/json' },
+    })
+    .then(({ data: { rows } }) => {
+      if (rows.length === 0) {
+        return [];
+      }
+
+      const landCoverMainClasses = JSON.parse(rows[0].land_cover_groups.replace(/'/g, '"'));
+      const landCoverMainClassesBreakdown = JSON.parse(
+        rows[0].land_cover_group_2018.replace(/'/g, '"')
+      );
+      const landCoverSubClasses = JSON.parse(rows[0].land_cover.replace(/'/g, '"'));
+
+      return parseChangeByLandCoverData(
+        landCoverMainClasses,
+        landCoverMainClassesBreakdown,
+        landCoverSubClasses
+      );
+    });
+};

--- a/api/charts/helpers.js
+++ b/api/charts/helpers.js
@@ -1,3 +1,5 @@
+const { LAYERS } = require('../../components/map/constants');
+
 /**
  * Parse the data of the timeseries chart
  * @param {number[]} years List of years
@@ -37,6 +39,44 @@ exports.parseChangeData = (counts, bins, average, area) => {
       bin: bins[index],
     })),
   };
+};
+
+/**
+ * Return the land cover legend item that corresponds to a land cover class ID
+ * @param {string} id ID of the land cover class
+ * @param {boolean} isMainClass Whether this is a main land cover class
+ */
+const getLandCoverClassLegendItem = (id, isMainClass = true) => {
+  if (isMainClass) {
+    return LAYERS['land-cover'].legend.items.find(({ id: itemId }) => itemId === id);
+  }
+
+  let res = null;
+  LAYERS['land-cover'].legend.items.some(({ items }) => {
+    const legendItem = items.find(({ id: itemId }) => itemId === id);
+    if (legendItem) {
+      res = legendItem;
+      return true;
+    }
+
+    return false;
+  });
+
+  return res;
+};
+
+/**
+ * Parse the data of the change by land cover chart
+ * @param {Record<string, Record<string, number>>[]} mainClasses Data for the main classes
+ * @param {Record<string, Record<string, number>>[]} mainClassesBreakdown Data breakdown for the main classes
+ * @param {Record<string, Record<string, Record<string, number>>>[]} subClasses Data for the subclasses
+ */
+exports.parseChangeByLandCoverData = (mainClasses, mainClassesBreakdown, subClasses) => {
+  return Object.keys(mainClasses).map(mainClassId => ({
+    id: mainClassId,
+    name: getLandCoverClassLegendItem(mainClassId).name,
+    breakdown: mainClasses[mainClassId],
+  }));
 };
 
 /**

--- a/api/charts/helpers.js
+++ b/api/charts/helpers.js
@@ -77,6 +77,11 @@ exports.parseChangeByLandCoverData = (mainClasses, mainClassesBreakdown, subClas
     name: getLandCoverClassLegendItem(mainClassId).name,
     breakdown: mainClasses[mainClassId],
     detailedBreakdown: mainClassesBreakdown[mainClassId],
+    subClasses: Object.keys(subClasses[mainClassId]).map(subClassId => ({
+      id: subClassId,
+      name: getLandCoverClassLegendItem(subClassId, false).name,
+      detailedBreakdown: subClasses[mainClassId][subClassId],
+    })),
   }));
 };
 

--- a/api/charts/helpers.js
+++ b/api/charts/helpers.js
@@ -76,6 +76,7 @@ exports.parseChangeByLandCoverData = (mainClasses, mainClassesBreakdown, subClas
     id: mainClassId,
     name: getLandCoverClassLegendItem(mainClassId).name,
     breakdown: mainClasses[mainClassId],
+    detailedBreakdown: mainClassesBreakdown[mainClassId],
   }));
 };
 

--- a/api/charts/helpers.js
+++ b/api/charts/helpers.js
@@ -139,3 +139,66 @@ exports.combineChangeData = (data, compareData) => {
     }),
   };
 };
+
+/**
+ * Combine two change by land cover data sets
+ * @param {ReturnType<typeof exports.parseChangeByLandCoverData>} data Change data
+ * @param {ReturnType<typeof exports.parseChangeByLandCoverData>} compareData Compare change data
+ */
+exports.combineChangeByLandCoverData = (data, compareData) => {
+  if (data === null || compareData === null) {
+    return null;
+  }
+
+  const res = data.map(mainClass => ({
+    ...mainClass,
+    compareBreakdown: {},
+    compareDetailedBreakdown: {},
+    subClasses: mainClass.subClasses.map(subClass => ({
+      ...subClass,
+      compareDetailedBreakdown: {},
+    })),
+  }));
+
+  compareData.forEach(compareMainClass => {
+    const mainClass = res.find(({ id }) => id === compareMainClass.id);
+    if (!mainClass) {
+      const newMainClass = {
+        id: compareMainClass.id,
+        name: compareMainClass.name,
+        breakdown: {},
+        compareBreakdown: compareMainClass.breakdown,
+        detailedBreakdown: {},
+        compareDetailedBreakdown: compareMainClass.detailedBreakdown,
+        subClasses: compareMainClass.subClasses.map(compareSubClass => ({
+          id: compareSubClass.id,
+          name: compareSubClass.name,
+          detailedBreakdown: {},
+          compareDetailedBreakdown: compareMainClass.detailedBreakdown,
+        })),
+      };
+
+      res.push(newMainClass);
+    } else {
+      mainClass.compareBreakdown = compareMainClass.breakdown;
+      mainClass.compareDetailedBreakdown = compareMainClass.detailedBreakdown;
+      compareMainClass.subClasses.forEach(compareSubClass => {
+        const subClass = mainClass.subClasses.find(({ id }) => id === compareSubClass.id);
+        if (!subClass) {
+          const newSubClass = {
+            id: compareSubClass.id,
+            name: compareSubClass.name,
+            detailedBreakdown: {},
+            compareDetailedBreakdown: compareSubClass.detailedBreakdown,
+          };
+
+          compareMainClass.subClasses.push(newSubClass);
+        } else {
+          subClass.compareDetailedBreakdown = compareSubClass.detailedBreakdown;
+        }
+      });
+    }
+  });
+
+  return res;
+};

--- a/api/charts/index.js
+++ b/api/charts/index.js
@@ -2,7 +2,11 @@ const getOnTheFlyData = require('./on-the-fly');
 const getTimeseriesData = require('./timeseries');
 const getChangeData = require('./change');
 const getChangeByLandCoverData = require('./change-by-land-cover');
-const { combineTimeseriesData, combineChangeData } = require('./helpers');
+const {
+  combineTimeseriesData,
+  combineChangeData,
+  combineChangeByLandCoverData,
+} = require('./helpers');
 
 module.exports = async (
   {
@@ -66,11 +70,22 @@ module.exports = async (
                 areaInterest: compareAreaInterest,
                 scenario,
               }),
+              changeByLandCover: await getChangeByLandCoverData({
+                layer,
+                type,
+                boundaries,
+                areaInterest: compareAreaInterest,
+                scenario,
+              }),
             };
 
       resData = {
         timeseries: combineTimeseriesData(data.timeseries, compareData.timeseries),
         change: combineChangeData(data.change, compareData.change),
+        changeByLandCover: combineChangeByLandCoverData(
+          data.changeByLandCover,
+          compareData.changeByLandCover
+        ),
       };
     }
 

--- a/api/charts/index.js
+++ b/api/charts/index.js
@@ -1,6 +1,7 @@
 const getOnTheFlyData = require('./on-the-fly');
 const getTimeseriesData = require('./timeseries');
 const getChangeData = require('./change');
+const getChangeByLandCoverData = require('./change-by-land-cover');
 const { combineTimeseriesData, combineChangeData } = require('./helpers');
 
 module.exports = async (
@@ -27,6 +28,13 @@ module.exports = async (
               scenario,
             }),
             change: await getChangeData({ layer, type, boundaries, depth, areaInterest, scenario }),
+            changeByLandCover: await getChangeByLandCoverData({
+              layer,
+              type,
+              boundaries,
+              areaInterest,
+              scenario,
+            }),
           };
 
     resData = data;

--- a/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/component.js
+++ b/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/component.js
@@ -189,7 +189,12 @@ const ChangeByLandCoverSection = ({
           <Checkbox
             id="land-cover-detailed-classes"
             checked={showDetailedClasses}
-            onChange={setShowDetailedClasses}
+            onChange={visible => {
+              setShowDetailedClasses(visible);
+              if (!visible) {
+                setClassId(null);
+              }
+            }}
           >
             Detailed land cover classes
           </Checkbox>

--- a/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/component.js
+++ b/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/component.js
@@ -114,8 +114,9 @@ const ChangeByLandCoverSection = ({
   );
 
   const onClickDownload = useCallback(() => {
-    logEvent('Areas of interest', 'download data', 'download time series data');
+    logEvent('Areas of interest', 'download data', 'download change by land cover data');
 
+    // TODO: we can improve the downloaded data by injecting the name of the classes
     const blob = new Blob([JSON.stringify({ data }, null, 2)], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
 
@@ -123,7 +124,7 @@ const ChangeByLandCoverSection = ({
     a.href = url;
     a.download = `${slugify(areaInterest.name)}-${
       compareAreaInterest ? `${slugify(compareAreaInterest.name)}-` : ''
-    }timeseries-data.json`;
+    }change-by-land-cover-data.json`;
     a.click();
   }, [data, areaInterest, compareAreaInterest]);
 

--- a/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/component.js
+++ b/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/component.js
@@ -1,0 +1,354 @@
+import React, { useMemo, useCallback } from 'react';
+import PropTypes from 'prop-types';
+import {
+  ResponsiveContainer,
+  BarChart,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Bar,
+  Label,
+  Tooltip,
+} from 'recharts';
+import min from 'lodash/min';
+import max from 'lodash/max';
+
+import { logEvent } from 'utils/analytics';
+import { slugify, getValuePrefixAndPow, getHumanReadableValue } from 'utils/functions';
+import { Switch, Dropdown } from 'components/forms';
+import LoadingSpinner from 'components/loading-spinner';
+import HintButton from 'components/hint-button';
+import NoDataMessage from 'components/explore/no-data-message';
+import { LAYERS } from 'components/map';
+
+const Y_AXIS_WIDTH = 90;
+
+const ChangeByLandCoverSection = ({
+  data,
+  loading,
+  error,
+  legendLayers,
+  socLayerState,
+  areaInterest,
+  compareAreaInterest,
+  updateLayer,
+  removeLayer,
+  addLayer,
+}) => {
+  const socLayerGroup = useMemo(
+    () => legendLayers.find(layer => layer.id === 'soc-stock' || layer.id === 'soc-experimental'),
+    [legendLayers]
+  );
+
+  const typeOptions = useMemo(
+    () => socLayerGroup.layers[0].extraParams.config.settings.type.options,
+    [socLayerGroup]
+  );
+
+  const typeOption = useMemo(
+    () =>
+      socLayerState.config.settings.type.options.find(
+        option => option.value === socLayerState.type
+      ),
+    [socLayerState]
+  );
+
+  const depthIndex = useMemo(
+    () =>
+      typeOption.settings.depth.options.findIndex(option => option.value === socLayerState.depth),
+    [typeOption, socLayerState]
+  );
+
+  const depthOption = useMemo(() => typeOption.settings.depth.options[depthIndex], [
+    typeOption,
+    depthIndex,
+  ]);
+
+  const year1Option = useMemo(
+    () =>
+      typeOption.settings.year.options.find(
+        option => option.value === `${typeOption.settings.year1?.defaultOption}`
+      ),
+    [typeOption]
+  );
+
+  const year2Option = useMemo(
+    () =>
+      typeOption.settings.year.options.find(
+        option => option.value === `${typeOption.settings.year2?.defaultOption}`
+      ),
+    [typeOption]
+  );
+
+  const landCoverActive = useMemo(() => legendLayers.some(layer => layer.id === 'land-cover'), [
+    legendLayers,
+  ]);
+
+  const [unitPrefix, unitPow] = useMemo(() => {
+    if (!error && !loading && data?.length > 0) {
+      const minValue = min(data.map(item => Object.values(item.breakdown)).flat());
+      const maxValue = max(data.map(item => Object.values(item.breakdown)).flat());
+      const maxAbsValue = max([Math.abs(minValue), maxValue]);
+      return getValuePrefixAndPow(maxAbsValue);
+    }
+
+    return getValuePrefixAndPow(0);
+  }, [error, loading, data]);
+
+  const onToggleLandCover = useCallback(() => {
+    if (landCoverActive) {
+      removeLayer('land-cover');
+    } else {
+      addLayer('land-cover');
+    }
+  }, [landCoverActive, removeLayer, addLayer]);
+
+  const onChangeDepth = useCallback(
+    ({ value }) => updateLayer({ id: socLayerState.id, depth: value }),
+    [socLayerState, updateLayer]
+  );
+
+  const onClickDownload = useCallback(() => {
+    logEvent('Areas of interest', 'download data', 'download time series data');
+
+    const blob = new Blob([JSON.stringify({ data }, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${slugify(areaInterest.name)}-${
+      compareAreaInterest ? `${slugify(compareAreaInterest.name)}-` : ''
+    }timeseries-data.json`;
+    a.click();
+  }, [data, areaInterest, compareAreaInterest]);
+
+  return (
+    <section className="change-by-land-cover-section">
+      <header className="mt-2 align-items-start">
+        <h4>Change by land cover</h4>
+        <div className="d-flex align-items-end flex-column-reverse pt-2">
+          <Switch
+            id="analysis-change-by-land-cover-toggle"
+            checked={landCoverActive}
+            onChange={onToggleLandCover}
+            className="-label-left"
+          >
+            Display on map
+          </Switch>
+          <HintButton
+            icon="download"
+            className="ml-3 mb-2"
+            onClick={onClickDownload}
+            disabled={!data || data.length === 0}
+          >
+            Download data
+          </HintButton>
+        </div>
+      </header>
+      {!!error && (
+        <div className="alert alert-danger mt-2" role="alert">
+          Unable to fetch the data.
+        </div>
+      )}
+      {loading && (
+        <div className="mt-2 text-center">
+          <LoadingSpinner transparent inline />
+        </div>
+      )}
+      {!error && !loading && (!data || data.length === 0) && <NoDataMessage />}
+      {!error && !loading && data?.length > 0 && (
+        <>
+          <div className="chart-intro">
+            Soil organic carbon change by land cover from{' '}
+            <strong>
+              {socLayerState.type === 'future'
+                ? typeOptions[1].settings.year2.defaultOption
+                : year1Option.label}
+            </strong>{' '}
+            to{' '}
+            <strong>
+              {socLayerState.type === 'future'
+                ? typeOptions[2].settings.year.options[
+                    typeOptions[2].settings.year.options.length - 1
+                  ].label
+                : year2Option.label}
+            </strong>
+            <br />
+            at{' '}
+            {typeOption.settings.depth.options.length > 1 && (
+              <Dropdown
+                options={typeOption.settings.depth.options}
+                value={depthOption}
+                onChange={onChangeDepth}
+              />
+            )}
+            {typeOption.settings.depth.options.length <= 1 && <strong>{depthOption.label}</strong>}.
+          </div>
+          <ResponsiveContainer width="100%" aspect={0.9}>
+            <BarChart
+              data={data}
+              margin={{ top: 50, right: 0, bottom: 45, left: 0 }}
+              layout="vertical"
+              stackOffset="sign"
+              barCategoryGap={'25%'}
+            >
+              <Tooltip
+                allowEscapeViewBox={{ x: false, y: true }}
+                offset={20}
+                content={({ payload }) => {
+                  if (!payload.length) {
+                    return null;
+                  }
+
+                  return (
+                    <div className="recharts-default-tooltip">
+                      <div className="recharts-tooltip-item">
+                        Land cover{' '}
+                        {socLayerState.type === 'future'
+                          ? typeOptions[1].settings.year2.defaultOption
+                          : year1Option.label}
+                      </div>
+                      <ul>
+                        {payload
+                          .sort(({ value: valueA }, { value: valueB }) => {
+                            if (valueA * valueB < 0) {
+                              return valueA < 0 ? -1 : 1;
+                            }
+
+                            return valueB - valueA;
+                          })
+                          .map(item => {
+                            // The value we receive is in tons, so we need to multiply it by 10⁶
+                            let formattedValue = getHumanReadableValue(
+                              (item.value * Math.pow(10, 6)) / Math.pow(10, unitPow)
+                            );
+
+                            formattedValue =
+                              item.value === 0 ? 0 : `${formattedValue} ${unitPrefix}g C`;
+
+                            return (
+                              <li key={item.name}>
+                                <div className="color-pill" style={{ background: item.color }} />
+                                <div>
+                                  <div>{item.name}</div>
+                                  <div className="recharts-tooltip-item">{formattedValue}</div>
+                                </div>
+                              </li>
+                            );
+                          })}
+                      </ul>
+                    </div>
+                  );
+                }}
+              />
+              <CartesianGrid horizontal={false} strokeDasharray="5 5" />
+              <XAxis
+                type="number"
+                axisLine={false}
+                tickLine={false}
+                tickMargin={10}
+                tickFormatter={value => {
+                  // The value we receive is in tons, so we need to multiply it by 10⁶
+                  const formattedValue = getHumanReadableValue(
+                    (value * Math.pow(10, 6)) / Math.pow(10, unitPow)
+                  );
+
+                  return value === 0 ? 0 : `${formattedValue}${unitPrefix}`;
+                }}
+              >
+                <Label
+                  position="insideBottomLeft"
+                  content={({ viewBox }) => {
+                    const LINE_HEIGHT = 16;
+                    return (
+                      <g className="recharts-text recharts-label">
+                        <text
+                          x={viewBox.width + Y_AXIS_WIDTH}
+                          y={viewBox.y + LINE_HEIGHT + 40}
+                          textAnchor="end"
+                        >
+                          SOC {socLayerState.id !== 'soc-stock' ? socLayerState.type : `stock`}
+                        </text>
+                        <text
+                          x={viewBox.width + Y_AXIS_WIDTH}
+                          y={viewBox.y + LINE_HEIGHT * 2 + 40}
+                          textAnchor="end"
+                        >
+                          (g C)
+                        </text>
+                      </g>
+                    );
+                  }}
+                />
+              </XAxis>
+              <YAxis
+                type="category"
+                dataKey="name"
+                axisLine={false}
+                tickLine={false}
+                interval={0}
+                width={Y_AXIS_WIDTH}
+                // Don't set `allowDuplicatedCategory={false}` as we loose the tooltip's payload
+              >
+                <Label
+                  position="insideTopRight"
+                  content={() => {
+                    const LINE_HEIGHT = 16;
+                    return (
+                      <g className="recharts-text recharts-label">
+                        <text x={Y_AXIS_WIDTH - 8} y={LINE_HEIGHT} textAnchor="end">
+                          Land cover
+                        </text>
+                        <text x={Y_AXIS_WIDTH - 8} y={LINE_HEIGHT * 2} textAnchor="end">
+                          2018
+                        </text>
+                      </g>
+                    );
+                  }}
+                />
+              </YAxis>
+
+              {LAYERS['land-cover'].legend.items.map(({ id, name, color }) => (
+                <Bar
+                  key={id}
+                  dataKey={`breakdown.${id}`}
+                  name={name}
+                  fill={color}
+                  stackId="stack"
+                />
+              ))}
+            </BarChart>
+          </ResponsiveContainer>
+        </>
+      )}
+    </section>
+  );
+};
+
+ChangeByLandCoverSection.propTypes = {
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      year: PropTypes.number.isRequired,
+      value: PropTypes.number.isRequired,
+      compareValue: PropTypes.number,
+    })
+  ),
+  loading: PropTypes.bool,
+  error: PropTypes.bool,
+  legendLayers: PropTypes.arrayOf(PropTypes.object).isRequired,
+  socLayerState: PropTypes.object.isRequired,
+  areaInterest: PropTypes.object.isRequired,
+  compareAreaInterest: PropTypes.object,
+  updateLayer: PropTypes.func.isRequired,
+  removeLayer: PropTypes.func.isRequired,
+  addLayer: PropTypes.func.isRequired,
+};
+
+ChangeByLandCoverSection.defaultProps = {
+  data: null,
+  loading: false,
+  error: false,
+  compareAreaInterest: null,
+};
+
+export default ChangeByLandCoverSection;

--- a/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/component.js
+++ b/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/component.js
@@ -220,7 +220,7 @@ const ChangeByLandCoverSection = ({
                     (value * Math.pow(10, 6)) / Math.pow(10, unitPow)
                   );
 
-                  return value === 0 ? 0 : `${formattedValue}${unitPrefix}`;
+                  return value === 0 ? 0 : formattedValue;
                 }}
               >
                 <Label
@@ -234,14 +234,15 @@ const ChangeByLandCoverSection = ({
                           y={viewBox.y + LINE_HEIGHT + 40}
                           textAnchor="end"
                         >
-                          SOC {socLayerState.id !== 'soc-stock' ? socLayerState.type : `stock`}
+                          SOC {socLayerState.id !== 'soc-stock' ? socLayerState.type : `stock`}{' '}
+                          change
                         </text>
                         <text
                           x={viewBox.width + Y_AXIS_WIDTH}
                           y={viewBox.y + LINE_HEIGHT * 2 + 40}
                           textAnchor="end"
                         >
-                          (g C)
+                          ({unitPrefix}g C)
                         </text>
                       </g>
                     );

--- a/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/component.js
+++ b/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/component.js
@@ -30,19 +30,25 @@ const ChangeByLandCoverSection = ({
   error,
   legendLayers,
   socLayerState,
+  landCoverLayerState,
   areaInterest,
   compareAreaInterest,
   updateLayer,
   removeLayer,
   addLayer,
 }) => {
-  // TODO: move to the Redux state to synchonize with the legend
-  const [showDetailedClasses, setShowDetailedClasses] = useState(false);
   const [classId, setClassId] = useState(null);
 
   const socLayerGroup = useMemo(
     () => legendLayers.find(layer => layer.id === 'soc-stock' || layer.id === 'soc-experimental'),
     [legendLayers]
+  );
+
+  const showDetailedClasses = useMemo(
+    () =>
+      landCoverLayerState.detailedClasses ??
+      landCoverLayerState.config.settings.detailedClasses.default,
+    [landCoverLayerState]
   );
 
   const typeOptions = useMemo(
@@ -104,6 +110,11 @@ const ChangeByLandCoverSection = ({
       addLayer('land-cover');
     }
   }, [landCoverActive, removeLayer, addLayer]);
+
+  const onChangeDetailedClasses = useCallback(
+    detailedClasses => updateLayer({ id: landCoverLayerState.id, detailedClasses }),
+    [landCoverLayerState, updateLayer]
+  );
 
   const onChangeDepth = useCallback(
     ({ value }) => updateLayer({ id: socLayerState.id, depth: value }),
@@ -220,13 +231,13 @@ const ChangeByLandCoverSection = ({
             id="land-cover-detailed-classes"
             checked={showDetailedClasses}
             onChange={visible => {
-              setShowDetailedClasses(visible);
+              onChangeDetailedClasses(visible);
               if (!visible) {
                 setClassId(null);
               }
             }}
           >
-            Detailed land cover classes
+            {landCoverLayerState.config.settings.detailedClasses.label}
           </Checkbox>
           <ResponsiveContainer width="100%" aspect={0.9}>
             <BarChart
@@ -343,6 +354,7 @@ ChangeByLandCoverSection.propTypes = {
   error: PropTypes.bool,
   legendLayers: PropTypes.arrayOf(PropTypes.object).isRequired,
   socLayerState: PropTypes.object.isRequired,
+  landCoverLayerState: PropTypes.object.isRequired,
   areaInterest: PropTypes.object.isRequired,
   compareAreaInterest: PropTypes.object,
   updateLayer: PropTypes.func.isRequired,

--- a/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/component.js
+++ b/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/component.js
@@ -162,7 +162,40 @@ const ChangeByLandCoverSection = ({
             .find(({ id }) => id === subClassId).name,
           value: subClass.detailedBreakdown[subClassId],
         })),
+        ...(compareAreaInterest
+          ? {
+              compareDetailedBreakdown: Object.keys(subClass.compareDetailedBreakdown).map(
+                subClassId => ({
+                  id: subClassId,
+                  name: LAYERS['land-cover'].legend.items
+                    .map(item => item.items)
+                    .flat()
+                    .find(({ id }) => id === subClassId).name,
+                  value: subClass.compareDetailedBreakdown[subClassId],
+                })
+              ),
+            }
+          : {}),
       })),
+      ...(compareAreaInterest
+        ? {
+            compareBreakdown: Object.keys(classItem.compareBreakdown).map(classId => ({
+              id: classId,
+              name: LAYERS['land-cover'].legend.items.find(({ id }) => id === classId).name,
+              value: classItem.compareBreakdown[classId],
+            })),
+            compareDetailedBreakdown: Object.keys(classItem.compareDetailedBreakdown).map(
+              subClassId => ({
+                id: subClassId,
+                name: LAYERS['land-cover'].legend.items
+                  .map(item => item.items)
+                  .flat()
+                  .find(({ id }) => id === subClassId).name,
+                value: classItem.compareDetailedBreakdown[subClassId],
+              })
+            ),
+          }
+        : {}),
     }));
 
     const blob = new Blob([JSON.stringify({ data: formattedData }, null, 2)], {

--- a/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/helpers.js
+++ b/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/helpers.js
@@ -40,7 +40,7 @@ export const useChartData = ({
 
       const values = chartData.map(item => Object.values(item.breakdown)).flat();
       const compareValues = compareAreaInterest
-        ? chartData.map(item => Object.values(item.compareBreakdown)).flat()
+        ? chartData.map(item => Object.values(item.compareBreakdown ?? {})).flat()
         : [];
 
       const minValue = min([values, compareValues].flat());
@@ -144,7 +144,7 @@ export const useChartData = ({
 
       const values = chartData.map(item => Object.values(item.detailedBreakdown)).flat();
       const compareValues = compareAreaInterest
-        ? chartData.map(item => Object.values(item.compareDetailedBreakdown)).flat()
+        ? chartData.map(item => Object.values(item.compareDetailedBreakdown ?? {})).flat()
         : [];
 
       const minValue = min([values, compareValues].flat());
@@ -182,7 +182,9 @@ export const useChartData = ({
           return [
             ...new Set([
               ...Object.keys(payload[0].payload.breakdown),
-              ...(compareAreaInterest ? Object.keys(payload[0].payload.compareBreakdown) : []),
+              ...(compareAreaInterest
+                ? Object.keys(payload[0].payload.compareBreakdown ?? {})
+                : []),
             ]),
           ]
             .map(id => {
@@ -201,7 +203,7 @@ export const useChartData = ({
                 value: payload[0].payload.breakdown[id],
                 ...(compareAreaInterest
                   ? {
-                      compareValue: payload[0].payload.compareBreakdown[id],
+                      compareValue: payload[0].payload.compareBreakdown?.[id] ?? null,
                     }
                   : {}),
               };
@@ -267,15 +269,17 @@ export const useChartData = ({
 
     const classObj = data.find(({ id }) => id === classId);
 
-    const chartData = [
-      // We inject the parent class' data to be shown at the top
-      classObj,
-      ...classObj.subClasses,
-    ];
+    const chartData = classObj
+      ? [
+          // We inject the parent class' data to be shown at the top
+          classObj,
+          ...classObj.subClasses,
+        ]
+      : [];
 
     const values = chartData.map(item => Object.values(item.detailedBreakdown)).flat();
     const compareValues = compareAreaInterest
-      ? chartData.map(item => Object.values(item.compareDetailedBreakdown)).flat()
+      ? chartData.map(item => Object.values(item.compareDetailedBreakdown ?? {})).flat()
       : [];
 
     const minValue = min([values, compareValues].flat());
@@ -314,7 +318,7 @@ export const useChartData = ({
           ...new Set([
             ...Object.keys(payload[0].payload.detailedBreakdown),
             ...(compareAreaInterest
-              ? Object.keys(payload[0].payload.compareDetailedBreakdown)
+              ? Object.keys(payload[0].payload.compareDetailedBreakdown ?? {})
               : []),
           ]),
         ]
@@ -335,7 +339,7 @@ export const useChartData = ({
               value: payload[0].payload.detailedBreakdown[id],
               ...(compareAreaInterest
                 ? {
-                    compareValue: payload[0].payload.compareDetailedBreakdown[id],
+                    compareValue: payload[0].payload.compareDetailedBreakdown?.[id] ?? null,
                   }
                 : {}),
             };

--- a/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/helpers.js
+++ b/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/helpers.js
@@ -1,0 +1,282 @@
+import React, { useMemo } from 'react';
+import min from 'lodash/min';
+import max from 'lodash/max';
+import { Text } from 'recharts';
+
+import Icon from 'components/icon';
+import { getHumanReadableValue, getValuePrefixAndPow } from 'utils/functions';
+import { LAYERS } from 'components/map/constants';
+
+const BUTTON_SIZE = 22;
+const BUTTON_SPACE = 26;
+const LABEL_MAX_CHAR = 25;
+
+export const useChartData = ({ error, loading, data, showDetailedClasses, classId }) => {
+  const res = useMemo(() => {
+    if (!!error || loading || !data || data.length === 0) {
+      const [unitPrefix, unitPow] = getValuePrefixAndPow(0);
+
+      return {
+        chartData: [],
+        barData: [],
+        dataKey: '',
+        unitPrefix,
+        unitPow,
+        getWidgetData: () => [],
+        getYAxisTick: () => undefined,
+      };
+    }
+
+    if (!showDetailedClasses) {
+      const chartData = data;
+
+      const values = chartData.map(item => Object.values(item.breakdown)).flat();
+
+      const minValue = min(values);
+      const maxValue = max(values);
+      const maxAbsValue = max([Math.abs(minValue), maxValue]);
+      const [unitPrefix, unitPow] = getValuePrefixAndPow(maxAbsValue);
+
+      return {
+        chartData,
+        barData: LAYERS['land-cover'].legend.items.map(item => ({
+          ...item,
+          dataKey: `breakdown.${item.id}`,
+        })),
+        unitPrefix,
+        unitPow,
+        getWidgetData: payload =>
+          payload.length === 0
+            ? []
+            : payload
+                .sort(({ value: valueA }, { value: valueB }) => {
+                  if (valueA * valueB < 0) {
+                    return valueA < 0 ? -1 : 1;
+                  }
+
+                  return valueB - valueA;
+                })
+                .map(({ name, value, color }) => ({
+                  name,
+                  color,
+                  value:
+                    value === 0
+                      ? 0
+                      : `${getHumanReadableValue(
+                          (value * Math.pow(10, 6)) / Math.pow(10, unitPow)
+                        )} ${unitPrefix}g C`,
+                })),
+        getYAxisTick: () => undefined,
+      };
+    }
+
+    if (classId === null) {
+      const chartData = data;
+
+      const values = chartData.map(item => Object.values(item.detailedBreakdown)).flat();
+
+      const minValue = min(values);
+      const maxValue = max(values);
+      const maxAbsValue = max([Math.abs(minValue), maxValue]);
+      const [unitPrefix, unitPow] = getValuePrefixAndPow(maxAbsValue);
+
+      return {
+        chartData,
+        barData: LAYERS['land-cover'].legend.items
+          .map(item => item.items)
+          .flat()
+          .map(item => ({
+            ...item,
+            dataKey: `detailedBreakdown.${item.id}`,
+          })),
+        unitPrefix,
+        unitPow,
+        getWidgetData: payload =>
+          payload.length === 0
+            ? []
+            : Object.keys(payload[0].payload.breakdown)
+                .map(id => {
+                  const legendItem = LAYERS['land-cover'].legend.items.find(
+                    ({ id: itemId }) => itemId === id
+                  );
+
+                  if (!legendItem) {
+                    return null;
+                  }
+
+                  return {
+                    id,
+                    name: legendItem.name,
+                    color: legendItem.color,
+                    value: payload[0].payload.breakdown[id],
+                  };
+                })
+                .sort(({ value: valueA }, { value: valueB }) => {
+                  if (valueA * valueB < 0) {
+                    return valueA < 0 ? -1 : 1;
+                  }
+
+                  return valueB - valueA;
+                })
+                .map(({ name, value, color }) => ({
+                  name,
+                  color,
+                  value:
+                    value === 0
+                      ? 0
+                      : `${getHumanReadableValue(
+                          (value * Math.pow(10, 6)) / Math.pow(10, unitPow)
+                        )} ${unitPrefix}g C`,
+                })),
+        // eslint-disable-next-line react/display-name
+        getYAxisTick: setClassId => ({ payload, x, y, width, ...props }) => (
+          <g>
+            <Text x={x - BUTTON_SPACE} y={y} width={width - BUTTON_SPACE} {...props}>
+              {payload.value}
+            </Text>
+            <foreignObject
+              x={x - BUTTON_SIZE}
+              y={y - BUTTON_SIZE / 2}
+              width={BUTTON_SIZE}
+              height={BUTTON_SIZE}
+            >
+              <button
+                type="button"
+                className="btn btn-sm btn-outline-primary class-button"
+                aria-label="See breakdown"
+                onClick={() => {
+                  const { id } = chartData[payload.index];
+                  setClassId(id);
+                }}
+              >
+                <Icon name="bottom-arrow" />
+              </button>
+            </foreignObject>
+          </g>
+        ),
+      };
+    }
+
+    const classObj = data.find(({ id }) => id === classId);
+
+    const chartData = [
+      // We inject the parent class' data to be shown at the top
+      classObj,
+      ...classObj.subClasses,
+    ];
+
+    const values = chartData.map(item => Object.values(item.detailedBreakdown)).flat();
+
+    const minValue = min(values);
+    const maxValue = max(values);
+    const maxAbsValue = max([Math.abs(minValue), maxValue]);
+    const [unitPrefix, unitPow] = getValuePrefixAndPow(maxAbsValue);
+
+    return {
+      chartData,
+      barData: LAYERS['land-cover'].legend.items
+        .map(item => item.items)
+        .flat()
+        .map(item => ({
+          ...item,
+          dataKey: `detailedBreakdown.${item.id}`,
+        })),
+      unitPrefix,
+      unitPow,
+      getWidgetData: payload =>
+        payload.length === 0
+          ? []
+          : Object.keys(payload[0].payload.detailedBreakdown)
+              .map(id => {
+                const legendItem = LAYERS['land-cover'].legend.items
+                  .map(item => item.items)
+                  .flat()
+                  .find(({ id: itemId }) => itemId === id);
+
+                if (!legendItem) {
+                  return null;
+                }
+
+                return {
+                  id,
+                  name: legendItem.name,
+                  color: legendItem.color,
+                  value: payload[0].payload.detailedBreakdown[id],
+                };
+              })
+              .sort(({ value: valueA }, { value: valueB }) => {
+                if (valueA * valueB < 0) {
+                  return valueA < 0 ? -1 : 1;
+                }
+
+                return valueB - valueA;
+              })
+              .map(({ name, value, color }) => ({
+                name,
+                color,
+                value:
+                  value === 0
+                    ? 0
+                    : `${getHumanReadableValue(
+                        (value * Math.pow(10, 6)) / Math.pow(10, unitPow)
+                      )} ${unitPrefix}g C`,
+              })),
+      // eslint-disable-next-line react/display-name
+      getYAxisTick: setClassId => ({ payload, x, y, width, ...props }) => {
+        let textLabel = payload.value;
+        if (textLabel.length > LABEL_MAX_CHAR) {
+          const words = textLabel.split(/\s/);
+
+          textLabel = '';
+          for (let index = 0, length = words.length; index < length; index++) {
+            const word = words[index];
+
+            if (textLabel.length + word.length > LABEL_MAX_CHAR) {
+              textLabel = `${textLabel}…`;
+              break;
+            }
+
+            textLabel = `${textLabel} ${word}`;
+          }
+        }
+
+        const showButton = payload.index === 0;
+
+        return (
+          <g>
+            <g>
+              <title>{payload.value}</title>
+              <Text
+                x={showButton ? x - BUTTON_SPACE : x}
+                y={y}
+                width={showButton ? width - BUTTON_SPACE : width}
+                {...props}
+              >
+                {textLabel}
+              </Text>
+            </g>
+            {showButton && (
+              <foreignObject
+                x={x - BUTTON_SIZE}
+                y={y - BUTTON_SIZE / 2}
+                width={BUTTON_SIZE}
+                height={BUTTON_SIZE}
+              >
+                <button
+                  type="button"
+                  className="btn btn-sm btn-outline-primary class-button -back"
+                  aria-label="Go back"
+                  onClick={() => setClassId(null)}
+                >
+                  <Icon name="bottom-arrow" />
+                </button>
+              </foreignObject>
+            )}
+          </g>
+        );
+      },
+    };
+  }, [error, loading, data, showDetailedClasses, classId]);
+
+  return res;
+};

--- a/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/index.js
+++ b/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/index.js
@@ -7,6 +7,7 @@ export default connect(
   state => ({
     legendLayers: mapSelectors.selectLegendDataLayers(state),
     socLayerState: mapSelectors.selectSOCLayerState(state),
+    landCoverLayerState: mapSelectors.selectLandCoverLayerState(state),
     areaInterest: analysisSelectors.selectAreaInterest(state),
     compareAreaInterest: analysisSelectors.selectCompareAreaInterest(state),
   }),

--- a/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/index.js
+++ b/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/index.js
@@ -1,0 +1,18 @@
+import { connect } from 'react-redux';
+
+import { mapSelectors, mapActions, analysisSelectors } from 'modules/explore';
+import Component from './component';
+
+export default connect(
+  state => ({
+    legendLayers: mapSelectors.selectLegendDataLayers(state),
+    socLayerState: mapSelectors.selectSOCLayerState(state),
+    areaInterest: analysisSelectors.selectAreaInterest(state),
+    compareAreaInterest: analysisSelectors.selectCompareAreaInterest(state),
+  }),
+  {
+    updateLayer: mapActions.updateLayer,
+    removeLayer: mapActions.removeLayer,
+    addLayer: mapActions.addLayer,
+  }
+)(Component);

--- a/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/widget-tooltip/component.js
+++ b/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/widget-tooltip/component.js
@@ -1,0 +1,117 @@
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+
+import { getHumanReadableValue } from 'utils/functions';
+import { LAYERS } from 'components/map/constants';
+
+const ChangeByLandCoverSectionWidgetTooltip = ({
+  payload,
+  detailedClasses,
+  unitPow,
+  unitPrefix,
+  legendLayers,
+  socLayerState,
+}) => {
+  const socLayerGroup = useMemo(
+    () => legendLayers.find(layer => layer.id === 'soc-stock' || layer.id === 'soc-experimental'),
+    [legendLayers]
+  );
+
+  const typeOptions = useMemo(
+    () => socLayerGroup.layers[0].extraParams.config.settings.type.options,
+    [socLayerGroup]
+  );
+
+  const typeOption = useMemo(
+    () =>
+      socLayerState.config.settings.type.options.find(
+        option => option.value === socLayerState.type
+      ),
+    [socLayerState]
+  );
+
+  const year1Option = useMemo(
+    () =>
+      typeOption.settings.year.options.find(
+        option => option.value === `${typeOption.settings.year1?.defaultOption}`
+      ),
+    [typeOption]
+  );
+
+  if (!payload.length) {
+    return null;
+  }
+
+  const payloadData = !detailedClasses
+    ? payload
+    : Object.keys(payload[0].payload.breakdown).map(id => {
+        const legendItem = LAYERS['land-cover'].legend.items.find(
+          ({ id: itemId }) => itemId === id
+        );
+
+        if (!legendItem) {
+          return null;
+        }
+
+        return {
+          id,
+          name: legendItem.name,
+          color: legendItem.color,
+          value: payload[0].payload.breakdown[id],
+        };
+      });
+
+  return (
+    <div className="recharts-default-tooltip">
+      <div className="recharts-tooltip-item">
+        Land cover{' '}
+        {socLayerState.type === 'future'
+          ? typeOptions[1].settings.year2.defaultOption
+          : year1Option.label}
+      </div>
+      <ul>
+        {payloadData
+          .sort(({ value: valueA }, { value: valueB }) => {
+            if (valueA * valueB < 0) {
+              return valueA < 0 ? -1 : 1;
+            }
+
+            return valueB - valueA;
+          })
+          .map(item => {
+            // The value we receive is in tons, so we need to multiply it by 10⁶
+            let formattedValue = getHumanReadableValue(
+              (item.value * Math.pow(10, 6)) / Math.pow(10, unitPow)
+            );
+
+            formattedValue = item.value === 0 ? 0 : `${formattedValue} ${unitPrefix}g C`;
+
+            return (
+              <li key={item.name}>
+                <div className="color-pill" style={{ background: item.color }} />
+                <div>
+                  <div>{item.name}</div>
+                  <div className="recharts-tooltip-item">{formattedValue}</div>
+                </div>
+              </li>
+            );
+          })}
+      </ul>
+    </div>
+  );
+};
+
+ChangeByLandCoverSectionWidgetTooltip.propTypes = {
+  payload: PropTypes.object.isRequired,
+  detailedClasses: PropTypes.bool,
+  unitPow: PropTypes.number.isRequired,
+  unitPrefix: PropTypes.string.isRequired,
+  legendLayers: PropTypes.arrayOf(PropTypes.object).isRequired,
+  socLayerState: PropTypes.object.isRequired,
+};
+
+ChangeByLandCoverSectionWidgetTooltip.defaultProps = {
+  detailedClasses: false,
+};
+
+export default ChangeByLandCoverSectionWidgetTooltip;

--- a/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/widget-tooltip/component.js
+++ b/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/widget-tooltip/component.js
@@ -41,12 +41,22 @@ const ChangeByLandCoverSectionWidgetTooltip = ({ payload, legendLayers, socLayer
           : year1Option.label}
       </div>
       <ul>
-        {payload.map(({ name, value, color }) => (
+        {payload.map(({ name, value, compareValue, color }) => (
           <li key={name}>
             <div className="color-pill" style={{ background: color }} />
-            <div className="name-value">
+            <div>
               <div>{name}</div>
-              <div className="recharts-tooltip-item">{value}</div>
+              <div className="values">
+                <div>
+                  {compareValue ? 'Top: ' : ''}
+                  <span className="recharts-tooltip-item">{value}</span>
+                </div>
+                {!!compareValue && (
+                  <div>
+                    Bottom: <span className="recharts-tooltip-item">{compareValue}</span>
+                  </div>
+                )}
+              </div>
             </div>
           </li>
         ))}

--- a/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/widget-tooltip/component.js
+++ b/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/widget-tooltip/component.js
@@ -1,17 +1,7 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 
-import { getHumanReadableValue } from 'utils/functions';
-import { LAYERS } from 'components/map/constants';
-
-const ChangeByLandCoverSectionWidgetTooltip = ({
-  payload,
-  detailedClasses,
-  unitPow,
-  unitPrefix,
-  legendLayers,
-  socLayerState,
-}) => {
+const ChangeByLandCoverSectionWidgetTooltip = ({ payload, legendLayers, socLayerState }) => {
   const socLayerGroup = useMemo(
     () => legendLayers.find(layer => layer.id === 'soc-stock' || layer.id === 'soc-experimental'),
     [legendLayers]
@@ -42,25 +32,6 @@ const ChangeByLandCoverSectionWidgetTooltip = ({
     return null;
   }
 
-  const payloadData = !detailedClasses
-    ? payload
-    : Object.keys(payload[0].payload.breakdown).map(id => {
-        const legendItem = LAYERS['land-cover'].legend.items.find(
-          ({ id: itemId }) => itemId === id
-        );
-
-        if (!legendItem) {
-          return null;
-        }
-
-        return {
-          id,
-          name: legendItem.name,
-          color: legendItem.color,
-          value: payload[0].payload.breakdown[id],
-        };
-      });
-
   return (
     <div className="recharts-default-tooltip">
       <div className="recharts-tooltip-item">
@@ -70,32 +41,15 @@ const ChangeByLandCoverSectionWidgetTooltip = ({
           : year1Option.label}
       </div>
       <ul>
-        {payloadData
-          .sort(({ value: valueA }, { value: valueB }) => {
-            if (valueA * valueB < 0) {
-              return valueA < 0 ? -1 : 1;
-            }
-
-            return valueB - valueA;
-          })
-          .map(item => {
-            // The value we receive is in tons, so we need to multiply it by 10⁶
-            let formattedValue = getHumanReadableValue(
-              (item.value * Math.pow(10, 6)) / Math.pow(10, unitPow)
-            );
-
-            formattedValue = item.value === 0 ? 0 : `${formattedValue} ${unitPrefix}g C`;
-
-            return (
-              <li key={item.name}>
-                <div className="color-pill" style={{ background: item.color }} />
-                <div>
-                  <div>{item.name}</div>
-                  <div className="recharts-tooltip-item">{formattedValue}</div>
-                </div>
-              </li>
-            );
-          })}
+        {payload.map(({ name, value, color }) => (
+          <li key={name}>
+            <div className="color-pill" style={{ background: color }} />
+            <div className="name-value">
+              <div>{name}</div>
+              <div className="recharts-tooltip-item">{value}</div>
+            </div>
+          </li>
+        ))}
       </ul>
     </div>
   );
@@ -103,15 +57,8 @@ const ChangeByLandCoverSectionWidgetTooltip = ({
 
 ChangeByLandCoverSectionWidgetTooltip.propTypes = {
   payload: PropTypes.object.isRequired,
-  detailedClasses: PropTypes.bool,
-  unitPow: PropTypes.number.isRequired,
-  unitPrefix: PropTypes.string.isRequired,
   legendLayers: PropTypes.arrayOf(PropTypes.object).isRequired,
   socLayerState: PropTypes.object.isRequired,
-};
-
-ChangeByLandCoverSectionWidgetTooltip.defaultProps = {
-  detailedClasses: false,
 };
 
 export default ChangeByLandCoverSectionWidgetTooltip;

--- a/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/widget-tooltip/index.js
+++ b/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/widget-tooltip/index.js
@@ -1,0 +1,9 @@
+import { connect } from 'react-redux';
+
+import { mapSelectors } from 'modules/explore';
+import Component from './component';
+
+export default connect(state => ({
+  legendLayers: mapSelectors.selectLegendDataLayers(state),
+  socLayerState: mapSelectors.selectSOCLayerState(state),
+}))(Component);

--- a/components/explore/tabs/areas-interest/analysis/component.js
+++ b/components/explore/tabs/areas-interest/analysis/component.js
@@ -11,6 +11,7 @@ import Tooltip from 'components/tooltip';
 import Compare from './compare';
 import TimeseriesSection from './timeseries-section';
 import ChangeSection from './change-section';
+import ChangeByLandCoverSection from './change-by-land-cover-section';
 import RankingSection from './ranking-section';
 import { useChartsData } from './helpers';
 
@@ -204,6 +205,14 @@ const Analysis = ({
           socLayerState.type === 'future') && (
           <TimeseriesSection data={data?.timeseries} loading={!data && !error} error={!!error} />
         )}
+        {socLayerState.id === 'soc-stock' &&
+          (socLayerState.type === 'recent' || socLayerState.type === 'future') && (
+            <ChangeByLandCoverSection
+              data={data?.changeByLandCover}
+              loading={!data && !error}
+              error={!!error}
+            />
+          )}
         {areaInterest.level === 0 && !compareAreaInterest && <RankingSection />}
       </div>
     </div>

--- a/components/explore/tabs/areas-interest/analysis/style.scss
+++ b/components/explore/tabs/areas-interest/analysis/style.scss
@@ -238,21 +238,6 @@
     }
   }
 
-  .recharts-default-tooltip {
-    padding: map-get($spacers, 2) !important;
-    font-family: $font-family-2;
-    @include font-size($font-size-xxs);
-    border: rem(1) solid $primary !important;
-    background: $body-bg !important;
-    box-shadow: $box-shadow-1;
-
-    .recharts-tooltip-item {
-      padding: 0 !important;
-      color: $body-color !important;
-      font-weight: $font-weight-medium;
-    }
-  }
-
   .change-by-land-cover-section {
     .chart-intro {
       margin-bottom: map-get($spacers, 2);
@@ -322,40 +307,72 @@
     .recharts-tooltip-wrapper {
       z-index: 10;
     }
+  }
+}
 
-    .recharts-default-tooltip {
-      width: rem(280);
+// The tooltip may be portaled and thus is outside the main class
+.recharts-default-tooltip {
+  padding: map-get($spacers, 2) !important;
+  font-family: $font-family-2;
+  @include font-size($font-size-xxs);
+  border: rem(1) solid $primary !important;
+  background: $body-bg !important;
+  box-shadow: $box-shadow-1;
 
-      ul {
-        list-style: none;
-        padding: 0;
-        margin: 0;
+  .recharts-tooltip-item {
+    padding: 0 !important;
+    color: $body-color !important;
+    font-weight: $font-weight-medium;
+  }
 
-        li {
-          display: flex;
-          margin-top: map-get($spacers, 2);
-        }
-      }
+  &.-change-by-land-cover {
+    min-width: rem(280);
+    z-index: 10;
 
-      .color-pill {
-        position: relative;
-        top: map-get($spacers, 1);
-        margin-right: map-get($spacers, 2);
-        width: rem(12);
-        height: rem(12);
-        flex-shrink: 0;
-      }
+    ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: inline-grid;
+      grid-auto-flow: column;
+      grid-template-rows: repeat(8, auto);
+      column-gap: map-get($spacers, 4);
 
-      .values {
+      li {
+        width: rem(310);
         display: flex;
-        flex-wrap: wrap;
+        margin-top: map-get($spacers, 2);
+      }
+    }
 
-        & > *:first-child {
-          margin-right: map-get($spacers, 2);
+    .color-pill {
+      position: relative;
+      top: map-get($spacers, 1);
+      margin-right: map-get($spacers, 2);
+      width: rem(12);
+      height: rem(12);
+      flex-shrink: 0;
+    }
 
-          &:after {
-            content: ' |';
-          }
+    .item {
+      overflow: hidden;
+    }
+
+    .name {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .values {
+      display: flex;
+      flex-wrap: wrap;
+
+      & > *:nth-child(2) {
+        margin-left: map-get($spacers, 2);
+
+        &:before {
+          content: '| ';
         }
       }
     }

--- a/components/explore/tabs/areas-interest/analysis/style.scss
+++ b/components/explore/tabs/areas-interest/analysis/style.scss
@@ -247,4 +247,45 @@
       font-weight: $font-weight-medium;
     }
   }
+
+  .change-by-land-cover-section {
+    .recharts-responsive-container {
+      overflow: visible;
+
+      svg {
+        overflow: visible;
+      }
+
+      .recharts-bar-rectangle {
+        path {
+          stroke: $body-bg;
+        }
+      }
+    }
+
+    .recharts-tooltip-wrapper {
+      z-index: 10;
+    }
+
+    .recharts-default-tooltip {
+      ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+
+        li {
+          display: flex;
+          margin-top: map-get($spacers, 2);
+        }
+      }
+
+      .color-pill {
+        position: relative;
+        top: map-get($spacers, 1);
+        margin-right: map-get($spacers, 2);
+        width: rem(12);
+        height: rem(12);
+      }
+    }
+  }
 }

--- a/components/explore/tabs/areas-interest/analysis/style.scss
+++ b/components/explore/tabs/areas-interest/analysis/style.scss
@@ -270,7 +270,45 @@
 
       .recharts-bar-rectangle {
         path {
-          stroke-width: 0;
+          stroke: $body-bg;
+        }
+      }
+
+      .-no-stroke {
+        .recharts-bar-rectangle {
+          path {
+            stroke-width: 0;
+          }
+        }
+      }
+
+      .class-button {
+        position: relative;
+        top: rem(2); // Needed for the focus ring
+        left: rem(2); // Needed for the focus ring
+        width: rem(18);
+        height: rem(18);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding: 0;
+        border: none;
+
+        .c-icon {
+          transform: rotate(-90deg);
+          transform-origin: center;
+          width: rem(12);
+          height: rem(12);
+
+          use {
+            stroke: currentColor;
+          }
+        }
+
+        &.-back {
+          .c-icon {
+            transform: rotate(90deg);
+          }
         }
       }
     }
@@ -280,7 +318,7 @@
     }
 
     .recharts-default-tooltip {
-      width: rem(200);
+      width: rem(280);
 
       ul {
         list-style: none;
@@ -300,6 +338,24 @@
         width: rem(12);
         height: rem(12);
         flex-shrink: 0;
+      }
+
+      .name-value {
+        display: flex;
+        overflow: hidden;
+
+        & > *:first-child {
+          margin-right: map-get($spacers, 2);
+          overflow: hidden;
+          white-space: nowrap;
+          text-overflow: ellipsis;
+
+        }
+
+        & > *:last-child {
+          flex-shrink: 0;
+          white-space: nowrap;
+        }
       }
     }
   }

--- a/components/explore/tabs/areas-interest/analysis/style.scss
+++ b/components/explore/tabs/areas-interest/analysis/style.scss
@@ -273,17 +273,18 @@
         overflow: visible;
       }
 
-      .recharts-bar-rectangle {
-        path {
-          stroke: $body-bg;
+      .recharts-xAxis {
+        .recharts-label {
+
+          .-light {
+            font-weight: $font-weight-normal;
+          }
         }
       }
 
-      .-no-stroke {
-        .recharts-bar-rectangle {
-          path {
-            stroke-width: 0;
-          }
+      .recharts-bar-rectangle {
+        path {
+          stroke-width: 0;
         }
       }
 
@@ -345,21 +346,16 @@
         flex-shrink: 0;
       }
 
-      .name-value {
+      .values {
         display: flex;
-        overflow: hidden;
+        flex-wrap: wrap;
 
         & > *:first-child {
           margin-right: map-get($spacers, 2);
-          overflow: hidden;
-          white-space: nowrap;
-          text-overflow: ellipsis;
 
-        }
-
-        & > *:last-child {
-          flex-shrink: 0;
-          white-space: nowrap;
+          &:after {
+            content: ' |';
+          }
         }
       }
     }

--- a/components/explore/tabs/areas-interest/analysis/style.scss
+++ b/components/explore/tabs/areas-interest/analysis/style.scss
@@ -155,6 +155,7 @@
 
       .recharts-label {
         @include font-size($font-size-xxs);
+        font-weight: $font-weight-medium;
         fill: $primary;
       }
     }
@@ -172,6 +173,10 @@
       .recharts-text {
         @include font-size($font-size-xxs);
         fill: $primary;
+      }
+
+      .recharts-label {
+        font-weight: $font-weight-medium;
       }
 
       .recharts-legend {

--- a/components/explore/tabs/areas-interest/analysis/style.scss
+++ b/components/explore/tabs/areas-interest/analysis/style.scss
@@ -249,6 +249,18 @@
   }
 
   .change-by-land-cover-section {
+    .chart-intro {
+      margin-bottom: map-get($spacers, 2);
+    }
+
+    .c-checkbox {
+      margin-bottom: map-get($spacers, 2);
+
+      label {
+        text-transform: uppercase;
+      }
+    }
+
     .recharts-responsive-container {
       overflow: visible;
 
@@ -258,7 +270,7 @@
 
       .recharts-bar-rectangle {
         path {
-          stroke: $body-bg;
+          stroke-width: 0;
         }
       }
     }
@@ -268,6 +280,8 @@
     }
 
     .recharts-default-tooltip {
+      width: rem(200);
+
       ul {
         list-style: none;
         padding: 0;
@@ -285,6 +299,7 @@
         margin-right: map-get($spacers, 2);
         width: rem(12);
         height: rem(12);
+        flex-shrink: 0;
       }
     }
   }

--- a/components/forms/checkbox/index.js
+++ b/components/forms/checkbox/index.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import './style.scss';
+
+const Checkbox = ({ id, disabled, checked, onChange, children, className }) => (
+  <div
+    className={[
+      'c-checkbox',
+      'custom-control',
+      'custom-checkbox',
+      ...(className ? [className] : []),
+    ].join(' ')}
+  >
+    <input
+      type="checkbox"
+      className="custom-control-input"
+      disabled={disabled}
+      id={id}
+      checked={checked}
+      onChange={() => onChange(!checked)}
+    />
+    <label className="custom-control-label" htmlFor={id}>
+      {children}
+    </label>
+  </div>
+);
+
+Checkbox.propTypes = {
+  id: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
+  checked: PropTypes.bool,
+  onChange: PropTypes.func,
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+};
+
+Checkbox.defaultProps = {
+  disabled: false,
+  checked: false,
+  onChange: () => null,
+  className: null,
+};
+
+export default Checkbox;

--- a/components/forms/checkbox/style.scss
+++ b/components/forms/checkbox/style.scss
@@ -1,0 +1,15 @@
+@import 'css/settings';
+
+.c-checkbox {
+  &.custom-checkbox {
+    .custom-control-label {
+      font-family: $font-family-2;
+      @include font-size($font-size-xxs);
+      line-height: $font-size-base * $line-height-base;
+
+      &::before {
+        border-radius: 0;
+      }
+    }
+  }
+}

--- a/components/map/constants.js
+++ b/components/map/constants.js
@@ -1243,88 +1243,264 @@ exports.LAYERS = {
       type: 'basic',
       items: [
         {
-          color: '#ffff64',
-          name: 'Cropland rainfed',
-        },
-        {
-          color: '#aaf0f0',
-          name: 'Cropland irrigated or post-flooding',
-        },
-        {
-          color: '#dcf064',
-          name: 'Mosaic cropland (>50%) / natural vegetation (<50%)',
-        },
-        {
-          color: '#c8c864',
-          name: 'Mosaic natural vegetation (>50%) / cropland (<50%)',
-        },
-        {
-          color: '#006400',
-          name: 'Tree cover broadleaved evergreen (>%15)',
-        },
-        {
-          color: '#00a000',
-          name: 'Tree cover broadleaved deciduous (>%15)',
-        },
-        {
-          color: '#003c00',
-          name: 'Tree cover needleleaved evergreen (>%15)',
-        },
-        {
-          color: '#285000',
-          name: 'Tree cover needleleaved deciduous (>%15)',
-        },
-        {
-          color: '#788200',
-          name: 'Tree cover mixed leaf type (broadleaved and needleleaved)',
-        },
-        {
-          color: '#8ca000',
-          name: 'Mosaic tree and shrub (>50%) / herbaceous cover (<50%)',
-        },
-        {
-          color: '#be9600',
-          name: 'Mosaic herbaceous cover (>50%) / tree and shrub (<50%)',
-        },
-        {
-          color: '#966400',
-          name: 'Shrubland',
-        },
-        {
-          color: '#ffb432',
-          name: 'Grassland',
-        },
-        {
-          color: '#ffdcd2',
-          name: 'Lichens and mosses',
-        },
-        {
-          color: '#ffebaf',
-          name: 'Sparse vegetation (<15%)',
-        },
-        {
-          color: '#00785a',
-          name: 'Tree cover flooded fresh/brakish water',
-        },
-        {
-          color: '#009678',
-          name: 'Tree cover flooded saline water',
-        },
-        {
-          color: '#00dc82',
-          name: 'Shrub or herbaceous cover flooded',
-        },
-        {
-          color: '#c31400',
-          name: 'Urban areas',
-        },
-        {
-          color: '#c31400',
-          name: 'Bare areas',
-        },
-        {
+          id: '0',
           color: '#ffffff',
-          name: 'Permanent snow and ice',
+          name: 'No Data',
+          items: [
+            {
+              id: '0',
+              color: '#ffffff',
+              name: 'No Data',
+            },
+          ],
+        },
+        {
+          id: '1',
+          color: '#dfc30c',
+          name: 'Cropland',
+          items: [
+            {
+              id: '10',
+              color: '#5B5B18',
+              name: 'Cropland rainfed',
+            },
+            {
+              id: '11',
+              color: '#7D7616',
+              name: 'Cropland rainfed herbaceous cover',
+            },
+            {
+              id: '20',
+              color: '#A09113',
+              name: 'Cropland irrigated or post-flooding',
+            },
+            {
+              id: '30',
+              color: '#C0AB10',
+              name: 'Mosaic cropland',
+            },
+            {
+              id: '40',
+              color: '#DFC30C',
+              name: 'Mosaic natural vegetation',
+            },
+          ],
+        },
+        {
+          id: '2',
+          color: '#0B842F',
+          name: 'Tree-cover areas',
+          items: [
+            {
+              id: '12',
+              color: '#124d00',
+              name: 'Cropland rainfed tree or shrub cover',
+            },
+            {
+              id: '50',
+              color: '#136010',
+              name: 'Tree broadleaved evergreen closed to open',
+            },
+            {
+              id: '60',
+              color: '#117221',
+              name: 'Tree broadleaved deciduous closed to open',
+            },
+            {
+              id: '61',
+              color: '#0b842f',
+              name: 'Tree broadleaved deciduous closed',
+            },
+            {
+              id: '62',
+              color: '#2a9339',
+              name: 'Tree broadleaved deciduous open',
+            },
+            {
+              id: '70',
+              color: '#4aa040',
+              name: 'Tree needleleaved evergreen closed to open',
+            },
+            {
+              id: '71',
+              color: '#64ac48',
+              name: 'Tree needleleaved evergreen closed',
+            },
+            {
+              id: '72',
+              color: '#7ab84f',
+              name: 'Tree needleleaved evergreen open',
+            },
+            {
+              id: '80',
+              color: '#91c357',
+              name: 'Tree needleleaved deciduous closed to open',
+            },
+            {
+              id: '81',
+              color: '#a5ce5f',
+              name: 'Tree needleleaved deciduous closed',
+            },
+            {
+              id: '82',
+              color: '#b9d867',
+              name: 'Tree needleleaved deciduous open',
+            },
+            {
+              id: '90',
+              color: '#cce36f',
+              name: 'Tree mixed',
+            },
+            {
+              id: '100',
+              color: '#e0ed78',
+              name: 'Mosaic tree and shrub',
+            },
+          ],
+        },
+        {
+          id: '3',
+          color: '#C69323',
+          name: 'Rangeland and pasture',
+          items: [
+            {
+              id: '110',
+              color: '#967216',
+              name: 'Mosaic herbaceous',
+            },
+            {
+              id: '120',
+              color: '#a67d1a',
+              name: 'Shrubland',
+            },
+            {
+              id: '121',
+              color: '#b6881f',
+              name: 'Shrubland evergreen',
+            },
+            {
+              id: '122',
+              color: '#c69323',
+              name: 'Shrubland deciduous',
+            },
+            {
+              id: '130',
+              color: '#d69e27',
+              name: 'Grassland',
+            },
+            {
+              id: '140',
+              color: '#e6a82b',
+              name: 'Lichens and mosses',
+            },
+            {
+              id: '150',
+              color: '#f6b148',
+              name: 'Sparse vegetation',
+            },
+            {
+              id: '151',
+              color: '#febc7a',
+              name: 'Sparse tree',
+            },
+            {
+              id: '152',
+              color: '#ffcaaa',
+              name: 'Sparse shrub',
+            },
+            {
+              id: '153',
+              color: '#f8dcd3',
+              name: 'Sparse herbaceous',
+            },
+          ],
+        },
+        {
+          id: '4',
+          color: '#016A6D',
+          name: 'Wetland',
+          items: [
+            {
+              id: '160',
+              color: '#016A6D',
+              name: 'Tree cover flooded fresh or brackish water',
+            },
+            {
+              id: '180',
+              color: '#35ADAD',
+              name: 'Shrub or herbaceous cover flooded',
+            },
+          ],
+        },
+        {
+          id: '5',
+          color: '#42DED5',
+          name: 'Mangroves',
+          items: [
+            {
+              id: '170',
+              color: '#42DED5',
+              name: 'Tree cover flooded saline water',
+            },
+          ],
+        },
+        {
+          id: '6',
+          color: '#3640B7',
+          name: 'Urban areas',
+          items: [
+            {
+              id: '190',
+              color: '#3640B7',
+              name: 'Urban areas',
+            },
+          ],
+        },
+        {
+          id: '7',
+          color: '#C54802',
+          name: 'Bare areas',
+          items: [
+            {
+              id: '200',
+              color: '#C54802',
+              name: 'Bare areas',
+            },
+            {
+              id: '201',
+              color: '#DF704F',
+              name: 'Bare areas consolidated',
+            },
+            {
+              id: '202',
+              color: '#FD9CA7',
+              name: 'Bare areas unconsolidated',
+            },
+          ],
+        },
+        {
+          id: '8',
+          color: '#48A7FF',
+          name: 'Water bodies',
+          items: [
+            {
+              id: '210',
+              color: '#48A7FF',
+              name: 'Water bodies',
+            },
+          ],
+        },
+        {
+          id: '9',
+          color: '#B9EEEF',
+          name: 'Snow and ice',
+          items: [
+            {
+              id: '220',
+              color: '#B9EEEF',
+              name: 'Snow and ice',
+            },
+          ],
         },
       ],
 

--- a/components/map/constants.js
+++ b/components/map/constants.js
@@ -1229,6 +1229,14 @@ exports.LAYERS = {
       "Land Cover from the European Space Agency's Climate Change Initiative Land Cover (ESA CCI-LC) dataset, categorized under the IPCC land cover classification system at 300 m resolution.",
     group: 'land-use',
     attributions: ['rw'],
+    paramsConfig: {
+      settings: {
+        detailedClasses: {
+          label: 'Detailed land cover classes',
+          default: false,
+        },
+      },
+    },
     config: {
       type: 'raster',
       source: (year = 2018) => {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "prettier": "1.19.1"
   },
   "dependencies": {
+    "@floating-ui/react": "^0.24.3",
     "@google/earthengine": "^0.1.239",
     "@reduxjs/toolkit": "^1.3.5",
     "@seznam/compose-react-refs": "^1.0.4",
@@ -73,6 +74,7 @@
     "react-select": "^3.1.0",
     "react-string-replace": "^0.4.4",
     "react-tabs": "^3.1.0",
+    "react-use": "^17.4.0",
     "recharts": "^1.8.5",
     "slugify": "^1.4.4",
     "swr": "^0.2.3",

--- a/utils/functions.js
+++ b/utils/functions.js
@@ -71,6 +71,27 @@ export const getHumanReadableValue = number => {
 };
 
 /**
+ * Return the scientific prefix (k, M, G, etc.) and power of 10 of a value
+ * @param {number} value Value to analyze in tons
+ * @returns {[string, number]}
+ */
+export const getValuePrefixAndPow = value => {
+  const factors = /** @type {[string, number][]} */ ([
+    ['P', 15],
+    ['T', 12],
+    ['G', 9],
+    ['M', 6],
+    ['k', 3],
+    ['', 0],
+  ]);
+
+  return factors.find(
+    // The value we receive is in tons, so we need to multiply it by 10⁶
+    ([, pow]) => Math.abs(value * Math.pow(10, 6)) / Math.pow(10, pow) > 1 || pow === 0
+  );
+};
+
+/**
  * Return the formatted value and its unit
  * @param {number} value Value to be formatted
  * @param {string} layer ID of the SOC layer
@@ -124,19 +145,7 @@ export const getFormattedValue = (value, layer, layerType, section) => {
         (layer === 'soc-stock' || (layer === 'soc-experimental' && layerType === 'stock')) &&
         (section === 'ranking-total' || section === 'analysis-change-total'),
       formatter: value => {
-        const factors = /** @type {[string, number][]} */ ([
-          ['P', 15],
-          ['T', 12],
-          ['G', 9],
-          ['M', 6],
-          ['k', 3],
-          ['', 0],
-        ]);
-
-        const [prefix, pow] = factors.find(
-          // The value we receive is in tons, so we need to multiply it by 10⁶
-          ([, pow]) => Math.abs(value * Math.pow(10, 6)) / Math.pow(10, pow) > 1 || pow === 0
-        );
+        const [prefix, pow] = getValuePrefixAndPow(value);
 
         return {
           unit: `${prefix}g C`,

--- a/utils/map.js
+++ b/utils/map.js
@@ -232,11 +232,17 @@ export const toggleRoads = (map, showRoads) => {
 };
 
 export const getLayerExtraParams = (layer, layerConfig) => {
-  if (layer.id === 'soc-experimental' || layer.id === 'soc-stock') {
-    return {
-      config: layer.paramsConfig,
-      // We only support two levels of nesting otherwise we'd need to recurse
-      ...Object.keys(layer.paramsConfig.settings).reduce((res, key) => {
+  if (!layer.paramsConfig) {
+    return undefined;
+  }
+
+  return {
+    config: layer.paramsConfig,
+    // We only support two levels of nesting otherwise we'd need to recurse
+    ...Object.keys(layer.paramsConfig.settings).reduce((res, key) => {
+      const setting = layer.paramsConfig.settings[key];
+
+      if (setting.options) {
         const value = layerConfig[key] || layer.paramsConfig.settings[key].defaultOption;
         const { settings } = layer.paramsConfig.settings[key].options.find(
           option => option.value === value
@@ -253,9 +259,19 @@ export const getLayerExtraParams = (layer, layerConfig) => {
             {}
           ),
         };
-      }, {}),
-    };
-  }
+      }
 
-  return undefined;
+      if (setting.default !== undefined) {
+        // If the layer is not visible, `layerConfig` will be `undefined`
+        const value = (layerConfig && layerConfig[key]) || layer.paramsConfig.settings[key].default;
+
+        return {
+          ...res,
+          [key]: value,
+        };
+      }
+
+      return res;
+    }, {}),
+  };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -440,6 +440,34 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
+"@floating-ui/core@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.3.1.tgz#4d795b649cc3b1cbb760d191c80dcb4353c9a366"
+  integrity sha512-Bu+AMaXNjrpjh41znzHqaz3r2Nr8hHuHZT6V2LBKMhyMl0FgKA62PNYbqnfgmzOhoWZj70Zecisbo4H1rotP5g==
+
+"@floating-ui/dom@^1.3.0":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.4.3.tgz#0854a3297ea03894932381f3ea1403fab3a6e602"
+  integrity sha512-nB/68NyaQlcdY22L+Fgd1HERQ7UGv7XFN+tPxwrEfQL4nKtAP/jIZnZtpUlXbtV+VEGHh6W/63Gy2C5biWI3sA==
+  dependencies:
+    "@floating-ui/core" "^1.3.1"
+
+"@floating-ui/react-dom@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.0.1.tgz#7972a4fc488a8c746cded3cfe603b6057c308a91"
+  integrity sha512-rZtAmSht4Lry6gdhAJDrCp/6rKN7++JnL1/Anbr/DdeyYXQPxvg/ivrbYvJulbRf4vL8b212suwMM2lxbv+RQA==
+  dependencies:
+    "@floating-ui/dom" "^1.3.0"
+
+"@floating-ui/react@^0.24.3":
+  version "0.24.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.24.3.tgz#4f11f09c7245555724f5167dd6925133457db89c"
+  integrity sha512-wWC9duiog4HmbgKSKObDRuXqMjZR/6m75MIG+slm5CVWbridAjK9STcnCsGYmdpK78H/GmzYj4ADVP8paZVLYQ==
+  dependencies:
+    "@floating-ui/react-dom" "^2.0.1"
+    aria-hidden "^1.1.3"
+    tabbable "^6.0.1"
+
 "@google/earthengine@^0.1.239":
   version "0.1.239"
   resolved "https://registry.yarnpkg.com/@google/earthengine/-/earthengine-0.1.239.tgz#d1148c05298118aaae5d7b0ec7b987b310dd5af0"
@@ -1434,6 +1462,11 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/js-cookie@^2.2.6":
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.7.tgz#226a9e31680835a6188e887f3988e60c04d3f6a3"
+  integrity sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==
+
 "@types/json-schema@^7.0.3":
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
@@ -1674,6 +1707,11 @@
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
+
+"@xobotyi/scrollbar-width@^1.9.5":
+  version "1.9.5"
+  resolved "https://registry.yarnpkg.com/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz#80224a6919272f405b87913ca13b92929bdf3c4d"
+  integrity sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -1951,6 +1989,13 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+aria-hidden@^1.1.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.2.3.tgz#14aeb7fb692bbb72d69bebfa47279c1fd725e954"
+  integrity sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==
+  dependencies:
+    tslib "^2.0.0"
 
 arity-n@^1.0.4:
   version "1.0.4"
@@ -3049,6 +3094,13 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+copy-to-clipboard@^3.3.1:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz#55ac43a1db8ae639a4bd99511c148cdd1b83a1b0"
+  integrity sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==
+  dependencies:
+    toggle-selection "^1.0.6"
+
 core-js@^2.4.0, core-js@^2.6.10:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
@@ -3178,6 +3230,13 @@ css-animation@^1.3.2:
     babel-runtime "6.x"
     component-classes "^1.2.5"
 
+css-in-js-utils@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz#640ae6a33646d401fc720c54fc61c42cd76ae2bb"
+  integrity sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==
+  dependencies:
+    hyphenate-style-name "^1.0.3"
+
 css-loader@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-1.0.0.tgz#9f46aaa5ca41dbe31860e3b62b8e23c42916bf56"
@@ -3222,6 +3281,14 @@ css-selector-tokenizer@^0.7.0:
     cssesc "^0.1.0"
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
+
+css-tree@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.3.tgz#eb4870fb6fd7707327ec95c2ff2ab09b5e8db91d"
+  integrity sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==
+  dependencies:
+    mdn-data "2.0.14"
+    source-map "^0.6.1"
 
 css.escape@^1.5.0:
   version "1.5.1"
@@ -3311,6 +3378,11 @@ csstype@^2.5.7, csstype@^2.6.7:
   version "2.6.10"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
   integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
+
+csstype@^3.0.6:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
+  integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -3840,6 +3912,13 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
+error-stack-parser@^2.0.6:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.1.4.tgz#229cb01cdbfa84440bfa91876285b94680188286"
+  integrity sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==
+  dependencies:
+    stackframe "^1.3.4"
+
 es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.2:
   version "1.17.4"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.4.tgz#e3aedf19706b20e7c2594c35fc0d57605a79e184"
@@ -4349,6 +4428,11 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
   integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
 
+fast-deep-equal@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
 fast-diff@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
@@ -4364,10 +4448,25 @@ fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-loops@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/fast-loops/-/fast-loops-1.1.3.tgz#ce96adb86d07e7bf9b4822ab9c6fac9964981f75"
+  integrity sha512-8EZzEP0eKkEEVX+drtd9mtuQ+/QrlfW/5MlwcwK5Nds6EkZ/tRzEexkzUY2mIssnAyVLT+TKHuRXmFNNXYUd6g==
+
+fast-shallow-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz#d4dcaf6472440dcefa6f88b98e3251e27f25628b"
+  integrity sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==
+
 fast-text-encoding@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.2.tgz#ff1ad5677bde049e0f8656aa6083a7ef2c5836e2"
   integrity sha512-5rQdinSsycpzvAoHga2EDn+LRX1d5xLFsuNG0Kg61JrAT/tASXcLL0nf/33v+sAxlQcfYmWbTURa1mmAf55jGw==
+
+fastest-stable-stringify@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz#3757a6774f6ec8de40c4e86ec28ea02417214c76"
+  integrity sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==
 
 fastparse@^1.1.1:
   version "1.1.2"
@@ -5104,6 +5203,11 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
+hyphenate-style-name@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"
+  integrity sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==
+
 iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -5252,6 +5356,14 @@ ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+
+inline-style-prefixer@^6.0.0:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-6.0.4.tgz#4290ed453ab0e4441583284ad86e41ad88384f44"
+  integrity sha512-FwXmZC2zbeeS7NzGjJ6pAiqRhXR0ugUShSNb6GApMl6da0/XGc4MOJsoWAywia52EEWbXNSy0pzkwz/+Y+swSg==
+  dependencies:
+    css-in-js-utils "^3.1.0"
+    fast-loops "^1.1.3"
 
 inquirer@^7.0.0:
   version "7.0.4"
@@ -6032,6 +6144,11 @@ js-base64@^2.1.8:
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.2.tgz#313b6274dda718f714d00b3330bbae6e38e90209"
   integrity sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ==
 
+js-cookie@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -6590,6 +6707,11 @@ mdast-add-list-metadata@1.0.1:
   dependencies:
     unist-util-visit-parents "1.1.2"
 
+mdn-data@2.0.14:
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
+  integrity sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
@@ -6877,6 +6999,20 @@ nan@^2.12.1, nan@^2.13.2:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
+
+nano-css@^5.3.1:
+  version "5.3.5"
+  resolved "https://registry.yarnpkg.com/nano-css/-/nano-css-5.3.5.tgz#3075ea29ffdeb0c7cb6d25edb21d8f7fa8e8fe8e"
+  integrity sha512-vSB9X12bbNu4ALBu7nigJgRViZ6ja3OU7CeuiV1zMIbXOdmkLahgtPmh3GBOlDxbKY0CitqlPdOReGlBLSp+yg==
+  dependencies:
+    css-tree "^1.1.2"
+    csstype "^3.0.6"
+    fastest-stable-stringify "^2.0.2"
+    inline-style-prefixer "^6.0.0"
+    rtl-css-js "^1.14.0"
+    sourcemap-codec "^1.4.8"
+    stacktrace-js "^2.0.2"
+    stylis "^4.0.6"
 
 nanoid@^3.1.16:
   version "3.1.18"
@@ -8485,6 +8621,31 @@ react-transition-group@^4.3.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
+react-universal-interface@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/react-universal-interface/-/react-universal-interface-0.6.2.tgz#5e8d438a01729a4dbbcbeeceb0b86be146fe2b3b"
+  integrity sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==
+
+react-use@^17.4.0:
+  version "17.4.0"
+  resolved "https://registry.yarnpkg.com/react-use/-/react-use-17.4.0.tgz#cefef258b0a6c534a5c8021c2528ac6e1a4cdc6d"
+  integrity sha512-TgbNTCA33Wl7xzIJegn1HndB4qTS9u03QUwyNycUnXaweZkE4Kq2SB+Yoxx8qbshkZGYBDvUXbXWRUmQDcZZ/Q==
+  dependencies:
+    "@types/js-cookie" "^2.2.6"
+    "@xobotyi/scrollbar-width" "^1.9.5"
+    copy-to-clipboard "^3.3.1"
+    fast-deep-equal "^3.1.3"
+    fast-shallow-equal "^1.0.0"
+    js-cookie "^2.2.1"
+    nano-css "^5.3.1"
+    react-universal-interface "^0.6.2"
+    resize-observer-polyfill "^1.5.1"
+    screenfull "^5.1.0"
+    set-harmonic-interval "^1.0.1"
+    throttle-debounce "^3.0.1"
+    ts-easing "^0.2.0"
+    tslib "^2.1.0"
+
 react-virtualized-auto-sizer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.2.tgz#a61dd4f756458bbf63bd895a92379f9b70f803bd"
@@ -8823,7 +8984,7 @@ reselect@^4.0.0:
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
   integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
 
-resize-observer-polyfill@^1.5.0:
+resize-observer-polyfill@^1.5.0, resize-observer-polyfill@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
   integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
@@ -8954,6 +9115,13 @@ rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
+
+rtl-css-js@^1.14.0:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/rtl-css-js/-/rtl-css-js-1.16.1.tgz#4b48b4354b0ff917a30488d95100fbf7219a3e80"
+  integrity sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
 
 run-async@^2.2.0:
   version "2.3.0"
@@ -9109,6 +9277,11 @@ schema-utils@^3.0.0:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
+screenfull@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-5.2.0.tgz#6533d524d30621fc1283b9692146f3f13a93d1ba"
+  integrity sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==
+
 scroll@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/scroll/-/scroll-3.0.1.tgz#d5afb59fb3592ee3df31c89743e78b39e4cd8a26"
@@ -9195,6 +9368,11 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+set-harmonic-interval@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz#e1773705539cdfb80ce1c3d99e7f298bb3995249"
+  integrity sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==
 
 set-value@^2.0.0, set-value@^2.0.1:
   version "2.0.1"
@@ -9423,6 +9601,11 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
+source-map@0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+  integrity sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==
+
 source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
@@ -9451,6 +9634,11 @@ source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
+
+sourcemap-codec@^1.4.8:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 spdx-correct@^3.0.0:
   version "3.1.0"
@@ -9524,10 +9712,39 @@ ssri@^6.0.1:
   dependencies:
     figgy-pudding "^3.5.1"
 
+stack-generator@^2.0.5:
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/stack-generator/-/stack-generator-2.0.10.tgz#8ae171e985ed62287d4f1ed55a1633b3fb53bb4d"
+  integrity sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==
+  dependencies:
+    stackframe "^1.3.4"
+
 stack-utils@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
   integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
+
+stackframe@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.3.4.tgz#b881a004c8c149a5e8efef37d51b16e412943310"
+  integrity sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==
+
+stacktrace-gps@^3.0.4:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/stacktrace-gps/-/stacktrace-gps-3.1.2.tgz#0c40b24a9b119b20da4525c398795338966a2fb0"
+  integrity sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==
+  dependencies:
+    source-map "0.5.6"
+    stackframe "^1.3.4"
+
+stacktrace-js@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/stacktrace-js/-/stacktrace-js-2.0.2.tgz#4ca93ea9f494752d55709a081d400fdaebee897b"
+  integrity sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==
+  dependencies:
+    error-stack-parser "^2.0.6"
+    stack-generator "^2.0.5"
+    stacktrace-gps "^3.0.4"
 
 stacktrace-parser@0.1.10:
   version "0.1.10"
@@ -9800,6 +10017,11 @@ stylis@3.5.4:
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
   integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
 
+stylis@^4.0.6:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.3.0.tgz#abe305a669fc3d8777e10eefcfc73ad861c5588c"
+  integrity sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ==
+
 supercluster@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-4.1.1.tgz#cf13c3b28a3fb3db5290bfad7f524e244bd4ce78"
@@ -9864,6 +10086,11 @@ symbol-tree@^3.2.2:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
+tabbable@^6.0.1:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.2.0.tgz#732fb62bc0175cfcec257330be187dcfba1f3b97"
+  integrity sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==
 
 table@^5.2.3:
   version "5.4.6"
@@ -9970,6 +10197,11 @@ throat@^5.0.0:
   resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
 
+throttle-debounce@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-3.0.1.tgz#32f94d84dfa894f786c9a1f290e7a645b6a19abb"
+  integrity sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==
+
 through2@^2.0.0:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
@@ -10061,6 +10293,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+toggle-selection@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
+  integrity sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==
+
 toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
@@ -10135,6 +10372,11 @@ tryer@^1.0.1:
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
+ts-easing@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ts-easing/-/ts-easing-0.2.0.tgz#c8a8a35025105566588d87dbda05dd7fbfa5a4ec"
+  integrity sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==
+
 ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
@@ -10144,6 +10386,11 @@ tslib@^1.8.1, tslib@^1.9.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.0.tgz#f1f3528301621a53220d58373ae510ff747a66bc"
   integrity sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg==
+
+tslib@^2.0.0, tslib@^2.1.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.0.tgz#b295854684dbda164e181d259a22cd779dcd7bc3"
+  integrity sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==
 
 tsutils@^3.17.1:
   version "3.17.1"


### PR DESCRIPTION
This PR adds a new “Change by land cover” widget in the Recent tab. The widget hasn't been tested yet with custom geometries.

## Testing instructions

−

## Tracking

[SOIL-34](https://vizzuality.atlassian.net/browse/SOIL-34)


[SOIL-34]: https://vizzuality.atlassian.net/browse/SOIL-34?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ