### PR TITLE
Add new “Change by land cover” widget in the Future tab

### DIFF
--- a/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/widget-tooltip/component.js
+++ b/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/widget-tooltip/component.js
@@ -46,7 +46,7 @@ const ChangeByLandCoverSectionWidgetTooltip = ({
     middleware: [offset({ crossAxis: y }), shift()],
   });
 
-  if (!open) {
+  if (!open || !payload.length) {
     return null;
   }
 
@@ -71,10 +71,10 @@ const ChangeByLandCoverSectionWidgetTooltip = ({
                 <div className="name">{name}</div>
                 <div className="values">
                   <div>
-                    {compareValue ? 'Top: ' : ''}
+                    {compareValue !== undefined ? 'Top: ' : ''}
                     <span className="recharts-tooltip-item">{value}</span>
                   </div>
-                  {!!compareValue && (
+                  {compareValue !== undefined && (
                     <div>
                       Bottom: <span className="recharts-tooltip-item">{compareValue}</span>
                     </div>

--- a/components/explore/tabs/areas-interest/analysis/style.scss
+++ b/components/explore/tabs/areas-interest/analysis/style.scss
@@ -267,6 +267,13 @@
         }
       }
 
+      .recharts-yAxis {
+        .-scenario {
+          font-weight: $font-weight-medium;
+          text-transform: uppercase;
+        }
+      }
+
       .recharts-bar-rectangle {
         path {
           stroke-width: 0;


### PR DESCRIPTION
This PR is the counterpart of #61 for the Future tab. The implementation hasn't been tested with the on-the-fly service.

## Testing instructions

-

## Pivotal Tracker

[SOIL-41](https://vizzuality.atlassian.net/browse/SOIL-41)


[SOIL-41]: https://vizzuality.atlassian.net/browse/SOIL-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ