### PR TITLE
Update the Global Land Cover layer

### DIFF
--- a/api/tiles/land-cover.js
+++ b/api/tiles/land-cover.js
@@ -7,43 +7,105 @@ const saveTile = require('./save-tile');
 const RAMP = `
   <RasterSymbolizer>
     <ColorMap type="values" extended="false">
-      <ColorMapEntry color="#ffff64" quantity="10" />
-      <ColorMapEntry color="#ffff64" quantity="11" />
-      <ColorMapEntry color="#ffff64" quantity="12" />
-      <ColorMapEntry color="#aaf0f0" quantity="20" />
-      <ColorMapEntry color="#dcf064" quantity="30" />
-      <ColorMapEntry color="#c8c864" quantity="40" />
-      <ColorMapEntry color="#006400" quantity="50" />
-      <ColorMapEntry color="#00a000" quantity="60" />
-      <ColorMapEntry color="#00a000" quantity="61" />
-      <ColorMapEntry color="#00a000" quantity="62" />
-      <ColorMapEntry color="#003c00" quantity="70" />
-      <ColorMapEntry color="#003c00" quantity="71" />
-      <ColorMapEntry color="#003c00" quantity="72" />
-      <ColorMapEntry color="#285000" quantity="80" />
-      <ColorMapEntry color="#285000" quantity="81" />
-      <ColorMapEntry color="#285000" quantity="82" />
-      <ColorMapEntry color="#788200" quantity="90" />
-      <ColorMapEntry color="#8ca000" quantity="100" />
-      <ColorMapEntry color="#be9600" quantity="110" />
-      <ColorMapEntry color="#966400" quantity="120" />
-      <ColorMapEntry color="#966400" quantity="121" />
-      <ColorMapEntry color="#966400" quantity="122" />
-      <ColorMapEntry color="#ffb432" quantity="130" />
-      <ColorMapEntry color="#ffdcd2" quantity="140" />
-      <ColorMapEntry color="#ffebaf" quantity="150" />
-      <ColorMapEntry color="#ffebaf" quantity="151" />
-      <ColorMapEntry color="#ffebaf" quantity="152" />
-      <ColorMapEntry color="#ffebaf" quantity="153" />
-      <ColorMapEntry color="#00785a" quantity="160" />
-      <ColorMapEntry color="#009678" quantity="170" />
-      <ColorMapEntry color="#00dc82" quantity="180" />
-      <ColorMapEntry color="#c31400" quantity="190" />
-      <ColorMapEntry color="#fff5d7" quantity="200" />
-      <ColorMapEntry color="#fff5d7" quantity="201" />
-      <ColorMapEntry color="#fff5d7" quantity="202" />
-      <ColorMapEntry color="#0046c8" quantity="210" opacity="0" />
-      <ColorMapEntry color="#ffffff" quantity="220" />
+      // Cropland
+      <ColorMapEntry color="#dfc30c" quantity="10" />
+      <ColorMapEntry color="#dfc30c" quantity="11" />
+      <ColorMapEntry color="#dfc30c" quantity="20" />
+      <ColorMapEntry color="#dfc30c" quantity="30" />
+      <ColorMapEntry color="#dfc30c" quantity="40" />
+      // Tree-covered areas
+      <ColorMapEntry color="#0B842F" quantity="12" />
+      <ColorMapEntry color="#0B842F" quantity="50" />
+      <ColorMapEntry color="#0B842F" quantity="60" />
+      <ColorMapEntry color="#0B842F" quantity="61" />
+      <ColorMapEntry color="#0B842F" quantity="62" />
+      <ColorMapEntry color="#0B842F" quantity="70" />
+      <ColorMapEntry color="#0B842F" quantity="71" />
+      <ColorMapEntry color="#0B842F" quantity="72" />
+      <ColorMapEntry color="#0B842F" quantity="80" />
+      <ColorMapEntry color="#0B842F" quantity="81" />
+      <ColorMapEntry color="#0B842F" quantity="82" />
+      <ColorMapEntry color="#0B842F" quantity="90" />
+      <ColorMapEntry color="#0B842F" quantity="100" />
+      // Rangeland and pasture
+      <ColorMapEntry color="#C69323" quantity="110" />
+      <ColorMapEntry color="#C69323" quantity="120" />
+      <ColorMapEntry color="#C69323" quantity="121" />
+      <ColorMapEntry color="#C69323" quantity="122" />
+      <ColorMapEntry color="#C69323" quantity="130" />
+      <ColorMapEntry color="#C69323" quantity="140" />
+      <ColorMapEntry color="#C69323" quantity="150" />
+      <ColorMapEntry color="#C69323" quantity="151" />
+      <ColorMapEntry color="#C69323" quantity="152" />
+      <ColorMapEntry color="#C69323" quantity="153" />
+      // Wetland
+      <ColorMapEntry color="#016A6D" quantity="160" />
+      <ColorMapEntry color="#016A6D" quantity="180" />
+      // Mangroves
+      <ColorMapEntry color="#42DED5" quantity="170" />
+      // Urban areas
+      <ColorMapEntry color="#3640B7" quantity="190" />
+      // Bare areas
+      <ColorMapEntry color="#C54802" quantity="200" />
+      <ColorMapEntry color="#C54802" quantity="201" />
+      <ColorMapEntry color="#C54802" quantity="202" />
+      // Water bodies
+      <ColorMapEntry color="#48A7FF" quantity="210" opacity="0" />
+      // Snow and ice
+      <ColorMapEntry color="#B9EEEF" quantity="220" opacity="0" />
+    </ColorMap>
+  </RasterSymbolizer>
+`;
+
+const DETAILED_RAMP = `
+  <RasterSymbolizer>
+    <ColorMap type="values" extended="false">
+      // Cropland
+      <ColorMapEntry color="#5B5B18" quantity="10" />
+      <ColorMapEntry color="#7D7616" quantity="11" />
+      <ColorMapEntry color="#A09113" quantity="20" />
+      <ColorMapEntry color="#C0AB10" quantity="30" />
+      <ColorMapEntry color="#DFC30C" quantity="40" />
+      // Tree-covered areas
+      <ColorMapEntry color="#124d00" quantity="12" />
+      <ColorMapEntry color="#136010" quantity="50" />
+      <ColorMapEntry color="#117221" quantity="60" />
+      <ColorMapEntry color="#0b842f" quantity="61" />
+      <ColorMapEntry color="#2a9339" quantity="62" />
+      <ColorMapEntry color="#4aa040" quantity="70" />
+      <ColorMapEntry color="#64ac48" quantity="71" />
+      <ColorMapEntry color="#7ab84f" quantity="72" />
+      <ColorMapEntry color="#91c357" quantity="80" />
+      <ColorMapEntry color="#a5ce5f" quantity="81" />
+      <ColorMapEntry color="#b9d867" quantity="82" />
+      <ColorMapEntry color="#cce36f" quantity="90" />
+      <ColorMapEntry color="#e0ed78" quantity="100" />
+      // Rangeland and pasture
+      <ColorMapEntry color="#967216" quantity="110" />
+      <ColorMapEntry color="#a67d1a" quantity="120" />
+      <ColorMapEntry color="#b6881f" quantity="121" />
+      <ColorMapEntry color="#c69323" quantity="122" />
+      <ColorMapEntry color="#d69e27" quantity="130" />
+      <ColorMapEntry color="#e6a82b" quantity="140" />
+      <ColorMapEntry color="#f6b148" quantity="150" />
+      <ColorMapEntry color="#febc7a" quantity="151" />
+      <ColorMapEntry color="#ffcaaa" quantity="152" />
+      <ColorMapEntry color="#f8dcd3" quantity="153" />
+      // Wetland
+      <ColorMapEntry color="#016A6D" quantity="160" />
+      <ColorMapEntry color="#35ADAD" quantity="180" />
+      // Mangroves
+      <ColorMapEntry color="#42DED5" quantity="170" />
+      // Urban areas
+      <ColorMapEntry color="#3640B7" quantity="190" />
+      // Bare areas
+      <ColorMapEntry color="#C54802" quantity="200" />
+      <ColorMapEntry color="#DF704F" quantity="201" />
+      <ColorMapEntry color="#FD9CA7" quantity="202" />
+      // Water bodies
+      <ColorMapEntry color="#48A7FF" quantity="210" opacity="0" />
+      // Snow and ice
+      <ColorMapEntry color="#B9EEEF" quantity="220" opacity="0" />
     </ColorMap>
   </RasterSymbolizer>
 `;
@@ -53,7 +115,7 @@ const sendImage = (res, data) => {
   return res.send(data);
 };
 
-const getOnTheFlyTile = async (year, x, y, z) => {
+const getOnTheFlyTile = async (group, year, x, y, z) => {
   return new Promise((resolve, reject) => {
     const image = ee
       .Image(
@@ -62,7 +124,7 @@ const getOnTheFlyTile = async (year, x, y, z) => {
           .filterDate(`${year}-01-01`, `${year}-12-31`)
           .first()
       )
-      .sldStyle(RAMP);
+      .sldStyle(group === 'simple' ? RAMP : DETAILED_RAMP);
 
     image.getMap({}, async ({ formatTileUrl }) => {
       const url = formatTileUrl(x, y, z);
@@ -77,15 +139,15 @@ const getOnTheFlyTile = async (year, x, y, z) => {
   });
 };
 
-module.exports = async ({ params: { year, x, y, z } }, res) => {
-  const S3Path = `land-cover/${year}/${z}/${x}/${y}`;
+module.exports = async ({ params: { group, year, x, y, z } }, res) => {
+  const S3Path = `land-cover/${group}/${year}/${z}/${x}/${y}`;
 
   try {
     const image = await getPregeneratedTile(S3Path);
     sendImage(res, image);
   } catch (e) {
     try {
-      const image = await getOnTheFlyTile(year, x, y, z);
+      const image = await getOnTheFlyTile(group, year, x, y, z);
 
       // We save the data to the S3 bucket
       if (+z <= +process.env.AWS_MAX_Z_TILE_STORAGE) {

--- a/api/validation/schemas.js
+++ b/api/validation/schemas.js
@@ -17,6 +17,9 @@ const tileSchema = Joi.object({
 
 module.exports = {
   landCover: tileSchema.append({
+    group: Joi.string()
+      .valid('simple', 'detailed')
+      .required(),
     year: Joi.number()
       .integer()
       .min(2000)

--- a/components/map/constants.js
+++ b/components/map/constants.js
@@ -1239,9 +1239,12 @@ exports.LAYERS = {
     },
     config: {
       type: 'raster',
-      source: (year = 2018) => {
+      source: ({ detailedClasses, currentDate }) => {
+        const year = currentDate ? currentDate.split('-')[0] : 2018;
+        const group = detailedClasses ? 'detailed' : 'simple';
+
         return {
-          tiles: [`${location.origin}/api/land-cover/${year}/{z}/{x}/{y}`],
+          tiles: [`${location.origin}/api/land-cover/${group}/${year}/{z}/{x}/{y}`],
           minzoom: 2,
           maxzoom: 12,
         };

--- a/components/map/legend/component.js
+++ b/components/map/legend/component.js
@@ -13,6 +13,7 @@ import Icon from 'components/icon';
 import LegendTitle from './title';
 import SOCExperimentalLegend from './soc-experimental';
 import SOCStockLegend from './soc-stock';
+import LandCoverLegend from './land-cover';
 
 import './style.scss';
 
@@ -90,15 +91,18 @@ const Legend = ({
             </LegendItemToolbar>
           }
         >
-          {layer.id !== 'soc-experimental' && layer.id !== 'soc-stock' && <LegendItemTypes />}
-          {layer.id !== 'soc-experimental' && layer.id !== 'soc-stock' && (
-            <LegendItemTimeStep handleChange={dates => onChangeDate(layer.id, dates)} />
-          )}
+          {layer.id !== 'soc-experimental' &&
+            layer.id !== 'soc-stock' &&
+            layer.id !== 'land-cover' && <LegendItemTypes />}
           {layer.id === 'soc-experimental' && (
             <SOCExperimentalLegend layerGroup={layer} onChangeParams={onChangeParams} />
           )}
           {layer.id === 'soc-stock' && (
             <SOCStockLegend layerGroup={layer} onChangeParams={onChangeParams} />
+          )}
+          {layer.id === 'land-cover' && <LandCoverLegend />}
+          {layer.id !== 'soc-experimental' && layer.id !== 'soc-stock' && (
+            <LegendItemTimeStep handleChange={dates => onChangeDate(layer.id, dates)} />
           )}
         </LegendListItem>
       ))}

--- a/components/map/legend/land-cover/component.js
+++ b/components/map/legend/land-cover/component.js
@@ -1,0 +1,108 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+
+import './style.scss';
+import { LAYERS } from 'components/map/constants';
+import Checkbox from 'components/forms/checkbox';
+import Icon from 'components/icon';
+
+const LandCover = ({ landCoverLayerState, updateLayer }) => {
+  const { items } = LAYERS['land-cover'].legend;
+
+  const [classId, setClassId] = useState(null);
+
+  const showDetailedClasses = useMemo(
+    () =>
+      landCoverLayerState.detailedClasses ??
+      landCoverLayerState.config.settings.detailedClasses.default,
+    [landCoverLayerState]
+  );
+
+  const activeClass = useMemo(() => {
+    if (classId === null) {
+      return null;
+    }
+
+    return LAYERS['land-cover'].legend.items.find(({ id }) => id === classId);
+  }, [classId]);
+
+  const onChangeDetailedClasses = useCallback(
+    detailedClasses => updateLayer({ id: landCoverLayerState.id, detailedClasses }),
+    [landCoverLayerState, updateLayer]
+  );
+
+  return (
+    <div className="c-map-legend-land-cover">
+      <Checkbox
+        id="legend-land-cover-detailed-classes"
+        checked={showDetailedClasses}
+        onChange={visible => {
+          onChangeDetailedClasses(visible);
+          if (!visible) {
+            setClassId(null);
+          }
+        }}
+      >
+        {landCoverLayerState.config.settings.detailedClasses.label}
+      </Checkbox>
+
+      {!activeClass && (
+        <ul className="list">
+          {items.map(({ id, name, color, items }) => (
+            <li key={id}>
+              <div className="color-pill" style={{ background: color }} />
+              <div className="item">
+                <div className="name">{name}</div>
+
+                {showDetailedClasses && items.length > 1 && (
+                  <button
+                    type="button"
+                    className="btn btn-sm btn-outline-primary class-button"
+                    aria-label="See breakdown"
+                    onClick={() => setClassId(id)}
+                  >
+                    <Icon name="bottom-arrow" />
+                  </button>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {!!activeClass && (
+        <>
+          <div className="active-class">
+            <button
+              type="button"
+              className="btn btn-sm btn-outline-primary class-button -back"
+              aria-label="Go back"
+              onClick={() => setClassId(null)}
+            >
+              <Icon name="bottom-arrow" />
+            </button>
+            {activeClass.name}
+          </div>
+
+          <ul className="list -no-column">
+            {activeClass.items.map(({ id, name, color }) => (
+              <li key={id}>
+                <div className="color-pill" style={{ background: color }} />
+                <div className="item">
+                  <div className="name">{name}</div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+};
+
+LandCover.propTypes = {
+  landCoverLayerState: PropTypes.object.isRequired,
+  updateLayer: PropTypes.func.isRequired,
+};
+
+export default LandCover;

--- a/components/map/legend/land-cover/index.js
+++ b/components/map/legend/land-cover/index.js
@@ -1,0 +1,13 @@
+import { connect } from 'react-redux';
+
+import { mapSelectors, mapActions } from 'modules/explore';
+import Component from './component';
+
+export default connect(
+  state => ({
+    landCoverLayerState: mapSelectors.selectLandCoverLayerState(state),
+  }),
+  {
+    updateLayer: mapActions.updateLayer,
+  }
+)(Component);

--- a/components/map/legend/land-cover/style.scss
+++ b/components/map/legend/land-cover/style.scss
@@ -1,0 +1,130 @@
+@import 'css/settings';
+
+.c-map-legend-land-cover {
+  .c-checkbox {
+    margin-bottom: map-get($spacers, 2);
+
+    label {
+      text-transform: uppercase;
+    }
+  }
+
+  .list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    grid-auto-flow: column;
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: repeat(5, auto);
+    column-gap: map-get($spacers, 2);
+
+    li {
+      padding: map-get($spacers, 2);
+      display: flex;
+      font-family: $font-family-2;
+      @include font-size($font-size-xxs);
+
+      .color-pill {
+        position: relative;
+        top: map-get($spacers, 1);
+      }
+
+      .class-button {
+        margin-left: map-get($spacers, 2);
+      }
+
+      &:hover {
+        background-color: rgba($black, 0.05);
+
+        .btn {
+          color: color-yiq($primary);
+          background-color: $primary;
+        }
+      }
+    }
+
+    &.-no-column {
+      display: block;
+
+      li {
+        padding: map-get($spacers, 1) map-get($spacers, 2);
+        @include font-size($font-size-xxxs);
+
+        .color-pill {
+          top: rem(2);
+        }
+
+        &:hover {
+          background-color: transparent;
+        }
+      }
+    }
+  }
+
+  .color-pill {
+    margin-right: map-get($spacers, 2);
+    width: rem(12);
+    height: rem(12);
+    flex-shrink: 0;
+  }
+
+  .item {
+    display: flex;
+    justify-content: space-between;
+    flex-grow: 1;
+  }
+
+  .class-button {
+    position: relative;
+    top: rem(1);
+    left: rem(1);
+    width: rem(18);
+    height: rem(18);
+    display: flex;
+    justify-content: center;
+    flex-shrink: 0;
+    align-items: center;
+    padding: 0;
+    border: none;
+
+    .c-icon {
+      transform: rotate(-90deg);
+      transform-origin: center;
+      width: rem(12);
+      height: rem(12);
+
+      use {
+        stroke: currentColor;
+      }
+    }
+
+    &.-back {
+      .c-icon {
+        transform: rotate(90deg);
+      }
+    }
+  }
+
+  .active-class {
+    display: flex;
+    width: calc(50% - #{map-get($spacers, 2) / 2});
+    padding: map-get($spacers, 2);
+    font-family: $font-family-2;
+    @include font-size($font-size-xxs);
+
+    .class-button {
+      flex-shrink: 0;
+      margin-right: map-get($spacers, 2);
+    }
+
+    &:hover {
+      background-color: rgba($black, 0.05);
+
+      .btn {
+        color: color-yiq($primary);
+        background-color: $primary;
+      }
+    }
+  }
+}

--- a/index.js
+++ b/index.js
@@ -36,7 +36,6 @@ const handle = app.getRequestHandler();
 // Initialize GEE
 let geePrivateKey;
 try {
-    
   geePrivateKey = require('./gee.key.json');
   ee.data.authenticateViaPrivateKey(
     geePrivateKey,
@@ -64,7 +63,7 @@ app.prepare().then(() => {
   // Tiles server handlers
   if (geePrivateKey) {
     server.get(
-      '/api/land-cover/:year/:z/:x/:y',
+      '/api/land-cover/:group/:year/:z/:x/:y',
       validation(schemas.landCover, 'params'),
       landCover
     );

--- a/utils/map.js
+++ b/utils/map.js
@@ -34,7 +34,7 @@ export const computeDecodeParams = (layer, { dateRange, currentDate }) => {
 
 export const getLayerSource = (layerId, layer, layerSettings) => {
   let source;
-  if (layerId === 'soc-experimental' || layerId === 'soc-stock') {
+  if (layerId === 'soc-experimental' || layerId === 'soc-stock' || layerId === 'land-cover') {
     source = layer.config.source(layerSettings);
   } else {
     source =


### PR DESCRIPTION
This PR updates the Global Land Cover layer so that:

- There are two views: one with the main land cover classes and another with all the subclasses
- The colour of the main classes are easier to differentiate and the colour of the subclasses are shades of the main classes

## Testing instructions

−

## Pivotal Tracker

[SOIL-27](https://vizzuality.atlassian.net/browse/SOIL-27)

[SOIL-27]: https://vizzuality.atlassian.net/browse/SOIL-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ