### PR TITLE
Add a reference line to the “Change by land cover” widget

### DIFF
--- a/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/component.js
+++ b/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/component.js
@@ -9,6 +9,7 @@ import {
   Bar,
   Label,
   Tooltip,
+  ReferenceLine,
 } from 'recharts';
 
 import { logEvent } from 'utils/analytics';
@@ -335,6 +336,7 @@ const ChangeByLandCoverSection = ({
                 }
               />
               <CartesianGrid horizontal={false} strokeDasharray="5 5" />
+              <ReferenceLine x={0} />
               <XAxis
                 type="number"
                 height={X_AXIS_HEIGHT}

--- a/components/explore/tabs/areas-interest/analysis/style.scss
+++ b/components/explore/tabs/areas-interest/analysis/style.scss
@@ -195,6 +195,12 @@
       }
     }
 
+    .recharts-reference-line-line {
+      // We can't use the `rgba` function here because there might be a cartesian grid line below
+      // the reference line
+      stroke: lighten($primary, 30%);
+    }
+
     .recharts-cartesian-grid,
     .recharts-reference-line,
     .recharts-tooltip-cursor:not(.recharts-rectangle) {


### PR DESCRIPTION
This PR adds a reference line on the 0 value of the “Change by land cover” widget.

<p align="center">
<img alt="Widget showing the detailed classes of the cropland main land cover class. There is a vertical darker line to represent the 0 value" src="https://github.com/Vizzuality/soils-revealed/assets/6073968/f97c18fd-2b25-47d3-8597-b40523d2b88a" />
</p>

## Testing instructions

−

## Pivotal Tracker

[SOIL-43](https://vizzuality.atlassian.net/browse/SOIL-43)

[SOIL-43]: https://vizzuality.atlassian.net/browse/SOIL-43?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ