### PR TITLE
Sort the “Change by land cover” widget's bars

### DIFF
--- a/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/component.js
+++ b/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/component.js
@@ -41,21 +41,11 @@ const ChangeByLandCoverSection = ({
   const prevCompareAreaInterest = usePrevious(compareAreaInterest);
   const chartRef = useRef();
 
-  const socLayerGroup = useMemo(
-    () => legendLayers.find(layer => layer.id === 'soc-stock' || layer.id === 'soc-experimental'),
-    [legendLayers]
-  );
-
   const showDetailedClasses = useMemo(
     () =>
       landCoverLayerState.detailedClasses ??
       landCoverLayerState.config.settings.detailedClasses.default,
     [landCoverLayerState]
-  );
-
-  const typeOptions = useMemo(
-    () => socLayerGroup.layers[0].extraParams.config.settings.type.options,
-    [socLayerGroup]
   );
 
   const typeOption = useMemo(
@@ -453,9 +443,17 @@ const ChangeByLandCoverSection = ({
 ChangeByLandCoverSection.propTypes = {
   data: PropTypes.arrayOf(
     PropTypes.shape({
-      year: PropTypes.number.isRequired,
-      value: PropTypes.number.isRequired,
-      compareValue: PropTypes.number,
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+      breakdown: PropTypes.objectOf(PropTypes.number).isRequired,
+      detailedBreakdown: PropTypes.objectOf(PropTypes.number).isRequired,
+      subClasses: PropTypes.arrayOf(
+        PropTypes.shape({
+          id: PropTypes.string.isRequired,
+          name: PropTypes.string.isRequired,
+          detailedBreakdown: PropTypes.objectOf(PropTypes.number),
+        })
+      ),
     })
   ),
   loading: PropTypes.bool,

--- a/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/helpers.js
+++ b/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/helpers.js
@@ -48,6 +48,7 @@ export const useChartData = ({
 
         chartData = scenarios
           .map(scenario => chartData.filter(({ group }) => group === scenario))
+          .filter(items => items.length > 0)
           .reduce(
             (res, items) => [
               ...res,
@@ -220,6 +221,7 @@ export const useChartData = ({
 
         chartData = scenarios
           .map(scenario => chartData.filter(({ group }) => group === scenario))
+          .filter(items => items.length > 0)
           .reduce(
             (res, items) => [
               ...res,

--- a/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/helpers.js
+++ b/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/helpers.js
@@ -62,6 +62,28 @@ export const useChartData = ({
             ],
             []
           );
+      } else {
+        chartData.sort((itemA, itemB) => {
+          const itemANegativeTotal = Object.values(itemA.breakdown).reduce(
+            (res, item) => res + (item < 0 ? item : 0),
+            0
+          );
+
+          const itemBNegativeTotal = Object.values(itemB.breakdown).reduce(
+            (res, item) => res + (item < 0 ? item : 0),
+            0
+          );
+
+          if (itemANegativeTotal === itemBNegativeTotal) {
+            return 0;
+          }
+
+          if (itemANegativeTotal < itemBNegativeTotal) {
+            return -1;
+          }
+
+          return 1;
+        });
       }
 
       const values = chartData.map(item => Object.values(item.breakdown)).flat();
@@ -212,6 +234,28 @@ export const useChartData = ({
             ],
             []
           );
+      } else {
+        chartData.sort((itemA, itemB) => {
+          const itemANegativeTotal = Object.values(itemA.detailedBreakdown).reduce(
+            (res, item) => res + (item < 0 ? item : 0),
+            0
+          );
+
+          const itemBNegativeTotal = Object.values(itemB.detailedBreakdown).reduce(
+            (res, item) => res + (item < 0 ? item : 0),
+            0
+          );
+
+          if (itemANegativeTotal === itemBNegativeTotal) {
+            return 0;
+          }
+
+          if (itemANegativeTotal < itemBNegativeTotal) {
+            return -1;
+          }
+
+          return 1;
+        });
       }
 
       const values = chartData.map(item => Object.values(item.detailedBreakdown)).flat();
@@ -430,7 +474,27 @@ export const useChartData = ({
       ? [
           // We inject the parent class' data to be shown at the top
           classObj,
-          ...classObj.subClasses,
+          ...classObj.subClasses.sort((itemA, itemB) => {
+            const itemANegativeTotal = Object.values(itemA.detailedBreakdown).reduce(
+              (res, item) => res + (item < 0 ? item : 0),
+              0
+            );
+
+            const itemBNegativeTotal = Object.values(itemB.detailedBreakdown).reduce(
+              (res, item) => res + (item < 0 ? item : 0),
+              0
+            );
+
+            if (itemANegativeTotal === itemBNegativeTotal) {
+              return 0;
+            }
+
+            if (itemANegativeTotal < itemBNegativeTotal) {
+              return -1;
+            }
+
+            return 1;
+          }),
         ]
       : [];
 
@@ -586,7 +650,7 @@ export const useChartData = ({
         );
       },
     };
-  }, [error, loading, data, showDetailedClasses, classId, compareAreaInterest]);
+  }, [error, loading, data, showDetailedClasses, classId, compareAreaInterest, isFuture]);
 
   return res;
 };

--- a/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/widget-tooltip/component.js
+++ b/components/explore/tabs/areas-interest/analysis/change-by-land-cover-section/widget-tooltip/component.js
@@ -91,7 +91,7 @@ const ChangeByLandCoverSectionWidgetTooltip = ({
 
 ChangeByLandCoverSectionWidgetTooltip.propTypes = {
   open: PropTypes.bool.isRequired,
-  payload: PropTypes.object.isRequired,
+  payload: PropTypes.array.isRequired,
   y: PropTypes.number.isRequired,
   chartRef: PropTypes.object.isRequired,
   legendLayers: PropTypes.arrayOf(PropTypes.object).isRequired,


### PR DESCRIPTION
This PR sorts the “Change by land cover” widget's bars from the one with biggest loss of carbon stock to smallest. The PR also fixes prop validations and a crash when moving from the Recent to Future tab.

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td>
<img alt="The bars are not sorted" src="https://github.com/Vizzuality/soils-revealed/assets/6073968/557a32d6-b5e8-4a7c-976d-e4fd5875ad43" />
</td>
    <td>
<img alt="The bars are sorted" src="https://github.com/Vizzuality/soils-revealed/assets/6073968/e0dcb3c3-1818-410d-af3c-51b4cf38ded1" />
</td>
  </tr>
</table>

## Testing instructions

−

## Pivotal Tracker

[SOIL-44](https://vizzuality.atlassian.net/browse/SOIL-44)


[SOIL-44]: https://vizzuality.atlassian.net/browse/SOIL-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ